### PR TITLE
Fix chipSelectPin initial state.

### DIFF
--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -21,7 +21,7 @@ MFRC522::MFRC522(	byte chipSelectPin,		///< Arduino pin connected to MFRC522's S
 	// Set the chipSelectPin as digital output, do not select the slave yet
 	_chipSelectPin = chipSelectPin;
 	pinMode(_chipSelectPin, OUTPUT);
-	digitalWrite(_chipSelectPin, LOW);
+	digitalWrite(_chipSelectPin, HIGH);
 	
 	// Set the resetPowerDownPin as digital output, do not reset or power down.
 	_resetPowerDownPin = resetPowerDownPin;
@@ -165,7 +165,7 @@ byte MFRC522::PCD_CalculateCRC(	byte *data,		///< In: Pointer to the data to tra
 	PCD_WriteRegister(FIFODataReg, length, data);		// Write data to the FIFO
 	PCD_WriteRegister(CommandReg, PCD_CalcCRC);		// Start the calculation
 	
-	// Wait for the CRC calculation to complete. Each iteration of the while-loop takes 17.73µs.
+	// Wait for the CRC calculation to complete. Each iteration of the while-loop takes 17.73ï¿½s.
 	word i = 5000;
 	byte n;
 	while (1) {
@@ -196,7 +196,7 @@ byte MFRC522::PCD_CalculateCRC(	byte *data,		///< In: Pointer to the data to tra
 void MFRC522::PCD_Init() {
 	if (digitalRead(_resetPowerDownPin) == LOW) { //The MFRC522 chip is in power down mode.
 		digitalWrite(_resetPowerDownPin, HIGH);	// Exit power down mode. This triggers a hard reset.
-		// Section 8.8.2 in the datasheet says the oscillator start-up time is the start up time of the crystal + 37,74µs. Let us be generous: 50ms.
+		// Section 8.8.2 in the datasheet says the oscillator start-up time is the start up time of the crystal + 37,74ï¿½s. Let us be generous: 50ms.
 		delay(50);
 	}
 	else { // Perform a soft reset
@@ -207,7 +207,7 @@ void MFRC522::PCD_Init() {
 	// f_timer = 13.56 MHz / (2*TPreScaler+1) where TPreScaler = [TPrescaler_Hi:TPrescaler_Lo].
 	// TPrescaler_Hi are the four low bits in TModeReg. TPrescaler_Lo is TPrescalerReg.
     PCD_WriteRegister(TModeReg, 0x80);			// TAuto=1; timer starts automatically at the end of the transmission in all communication modes at all speeds
-    PCD_WriteRegister(TPrescalerReg, 0xA9);	// TPreScaler = TModeReg[3..0]:TPrescalerReg, ie 0x0A9 = 169 => f_timer=40kHz, ie a timer period of 25µs.
+    PCD_WriteRegister(TPrescalerReg, 0xA9);	// TPreScaler = TModeReg[3..0]:TPrescalerReg, ie 0x0A9 = 169 => f_timer=40kHz, ie a timer period of 25ï¿½s.
     PCD_WriteRegister(TReloadRegH, 0x03);		// Reload timer with 0x3E8 = 1000, ie 25ms before timeout.
     PCD_WriteRegister(TReloadRegL, 0xE8);
 	
@@ -223,7 +223,7 @@ void MFRC522::PCD_Reset() {
 	PCD_WriteRegister(CommandReg, PCD_SoftReset);	// Issue the SoftReset command.
 	// The datasheet does not mention how long the SoftRest command takes to complete.
 	// But the MFRC522 might have been in soft power-down mode (triggered by bit 4 of CommandReg) 
-	// Section 8.8.2 in the datasheet says the oscillator start-up time is the start up time of the crystal + 37,74µs. Let us be generous: 50ms.
+	// Section 8.8.2 in the datasheet says the oscillator start-up time is the start up time of the crystal + 37,74ï¿½s. Let us be generous: 50ms.
 	delay(50);
 	// Wait for the PowerDown bit in CommandReg to be cleared
 	while (PCD_ReadRegister(CommandReg) & (1<<4)) {
@@ -299,7 +299,7 @@ byte MFRC522::PCD_CommunicateWithPICC(	byte command,		///< The command to execut
 	
 	// Wait for the command to complete.
 	// In PCD_Init() we set the TAuto flag in TModeReg. This means the timer automatically starts when the PCD stops transmitting.
-	// Each iteration of the do-while-loop takes 17.86µs.
+	// Each iteration of the do-while-loop takes 17.86ï¿½s.
 	i = 2000;
 	while (1) {
 		n = PCD_ReadRegister(ComIrqReg);	// ComIrqReg[7..0] bits are: Set1 TxIRq RxIRq IdleIRq   HiAlertIRq LoAlertIRq ErrIRq TimerIRq


### PR DESCRIPTION
Set chipSelectPin to HIGH on initiation, to not select the slave until needed. This avoids issues when using multiple devices on the same SPI bus.
