### PR TITLE
Updated the DumpInfo example

### DIFF
--- a/examples/DumpInfo/DumpInfo.ino
+++ b/examples/DumpInfo/DumpInfo.ino
@@ -14,12 +14,12 @@
  * below), load this sketch into Arduino IDE then verify/compile and upload it.
  * To see the output: use Tools, Serial Monitor of the IDE (hit Ctrl+Shft+M).
  * When you present a PICC (that is: a RFID Tag or Card) at reading distance
- * of the MFRC522 Reader/PCD, the output will show the ID, type and any data
- * blocks it can read. Note that you may see some "Timeout in communication"
- * messages when removing the PICC from reading distance to early.
+ * of the MFRC522 Reader/PCD, the serial output will show the ID/UID, type and
+ * any data blocks it can read. Note: you may see "Timeout in communication"
+ * messages when removing the PICC from reading distance too early.
  * 
  * If your reader supports it, this sketch/program will read all the PICCs
- * presented (that is: multiple tag reading). So if you stack* two or more
+ * presented (that is: multiple tag reading). So if you stack two or more
  * PICCs on top of each other and present them to the reader, it will first
  * output all details of the first and then the next PICC. Note that this
  * may take some time as all data blocks are dumped, so keep the PICCs at
@@ -27,15 +27,15 @@
  * 
  * Typical pin layout used:
  * ------------------------------------------------------------
- *             MFRC522      Arduino   Arduino   Arduino
- *             Reader/PCD   Uno       Mega      Nano v3
- * Signal      Pin          Pin       Pin       Pin
+ *             MFRC522      Arduino       Arduino   Arduino
+ *             Reader/PCD   Uno           Mega      Nano v3
+ * Signal      Pin          Pin           Pin       Pin
  * ------------------------------------------------------------
- * RST/Reset   RST          9         5         D9
- * SPI SS      SDA          10        53        D10
- * SPI MOSI    MOSI         11        51        D11
- * SPI MISO    MISO         12        50        D12
- * SPI SCK     SCK          13        52        D13
+ * RST/Reset   RST          9             5         D9
+ * SPI SS      SDA(SS)      10            53        D10
+ * SPI MOSI    MOSI         11 / ICSP-4   51        D11
+ * SPI MISO    MISO         12 / ICSP-1   50        D12
+ * SPI SCK     SCK          13 / ICSP-3   52        D13
  */
 
 #include <SPI.h>


### PR DESCRIPTION
Updated the `DumpInfo.ino` example sketch/program:
- Changed the description, to show that it is an example for the MFRC522 library
- Added link to the GitHub based project for the MFRC522 library
- Expanded the description of the example: what is does, basic instructions to use it (and how to see the output it generates...); and what to expect in some situations
- Updated the pin layout based on #48 updated README
- Added a `ShowReaderDetails()` called from the ``setup()` to output the MFRC522 software version information, as described in #27; which should also help detect any misconfiguration
