### PR TITLE
Updated the ReadAndWrite example

### DIFF
--- a/examples/ReadAndWrite/ReadAndWrite.ino
+++ b/examples/ReadAndWrite/ReadAndWrite.ino
@@ -1,240 +1,198 @@
-/*
- * MFRC522 - Library to use ARDUINO RFID MODULE KIT 13.56 MHZ WITH TAGS SPI W AND R BY COOQROBOT.
- * The library file MFRC522.h has a wealth of useful info. Please read it.
- * The functions are documented in MFRC522.cpp.
- *
- * Based on code Dr.Leong   ( WWW.B2CQSHOP.COM )
- * Created by Miguel Balboa (circuitito.com), Jan, 2012.
- * Rewritten by Søren Thing Andersen (access.thing.dk), fall of 2013 (Translation to English, refactored, comments, anti collision, cascade levels.)
+/**
+ * ----------------------------------------------------------------------------
+ * This is a MFRC522 library example; see https://github.com/miguelbalboa/rfid
+ * for further details and other examples.
+ * 
+ * NOTE: The library file MFRC522.h has a lot of useful info. Please read it.
  * 
  * Released into the public domain.
- *
- * This sample shows how to setup a block on a MIFARE Classic PICC to be in "Value Block" mode.
- * In Value Block mode the operations Increment/Decrement/Restore and Transfer can be used.
+ * ----------------------------------------------------------------------------
+ * This sample shows how to read and write data blocks on a MIFARE Classic PICC
+ * (= card/tag).
  * 
- ----------------------------------------------------------------------------- empty_skull 
- 
- - Aggiunti pin per arduino Mega
- - Scritto semplice codice per la scrittura e lettura 
- 
- - add pin configuration for arduino mega
- - write simple read/write Code for new entry user
- 
- http://mac86project.altervista.org/
- 
- ----------------------------------------------------------------------------- Nicola Coppola
- * Pin layout should be as follows:
- * Signal     Pin              Pin               Pin
- *            Arduino Uno      Arduino Mega      MFRC522 board
+ * BEWARE: Data will be written to the PICC, in sector #1 (blocks #4 to #7).
+ * 
+ * 
+ * Typical pin layout used:
  * ------------------------------------------------------------
- * Reset      9                5                 RST
- * SPI SS     10               53                SDA
- * SPI MOSI   11               51                MOSI
- * SPI MISO   12               50                MISO
- * SPI SCK    13               52                SCK
- *
- * The reader can be found on eBay for around 5 dollars. Search for "mf-rc522" on ebay.com. 
+ *             MFRC522      Arduino       Arduino   Arduino
+ *             Reader/PCD   Uno           Mega      Nano v3
+ * Signal      Pin          Pin           Pin       Pin
+ * ------------------------------------------------------------
+ * RST/Reset   RST          9             5         D9
+ * SPI SS      SDA(SS)      10            53        D10
+ * SPI MOSI    MOSI         11 / ICSP-4   51        D11
+ * SPI MISO    MISO         12 / ICSP-1   50        D12
+ * SPI SCK     SCK          13 / ICSP-3   52        D13
  */
 
 #include <SPI.h>
 #include <MFRC522.h>
 
-#define SS_PIN 10
-#define RST_PIN 9
-MFRC522 mfrc522(SS_PIN, RST_PIN);        // Create MFRC522 instance.
+#define RST_PIN         9           // Configurable, see typical pin layout above
+#define SS_PIN          10          // Configurable, see typical pin layout above
 
+MFRC522 mfrc522(SS_PIN, RST_PIN);   // Create MFRC522 instance.
+
+MFRC522::MIFARE_Key key;
+
+/**
+ * Initialize.
+ */
 void setup() {
-        Serial.begin(9600);        // Initialize serial communications with the PC
-        SPI.begin();                // Init SPI bus
-        mfrc522.PCD_Init();        // Init MFRC522 card
-        //Serial.println("Scan a MIFARE Classic PICC to demonstrate Value Blocks.");
+    Serial.begin(9600); // Initialize serial communications with the PC
+    SPI.begin();        // Init SPI bus
+    mfrc522.PCD_Init(); // Init MFRC522 card
+
+    // Prepare the key (used both as key A and as key B)
+    // using FFFFFFFFFFFFh which is the default at chip delivery from the factory
+    for (byte i = 0; i < 6; i++) {
+        key.keyByte[i] = 0xFF;
+    }
+
+    Serial.println("Scan a MIFARE Classic PICC to demonstrate read and write.");
+    Serial.print("Using key (for A and B):");
+    dump_byte_array(key.keyByte, MFRC522::MF_KEY_SIZE);
+    Serial.println();
+    
+    Serial.println("BEWARE: Data will be written to the PICC, in sector #1");
 }
 
+/**
+ * Main loop.
+ */
 void loop() {
-        
-        // Prepare key - all keys are set to FFFFFFFFFFFFh at chip delivery from the factory.
-        MFRC522::MIFARE_Key key;
-        for (byte i = 0; i < 6; i++) {
-                key.keyByte[i] = 0xFF;
-        }
-        // Look for new cards
-        if ( ! mfrc522.PICC_IsNewCardPresent()) {
-                return;
-        }
+    // Look for new cards
+    if ( ! mfrc522.PICC_IsNewCardPresent())
+        return;
 
-        // Select one of the cards
-        if ( ! mfrc522.PICC_ReadCardSerial()) {
-                return;
-        }
-        // Now a card is selected. The UID and SAK is in mfrc522.uid.
-        
-        // Dump UID
-        Serial.print("Card UID:");
-        for (byte i = 0; i < mfrc522.uid.size; i++) {
-                Serial.print(mfrc522.uid.uidByte[i] < 0x10 ? " 0" : " ");
-                Serial.print(mfrc522.uid.uidByte[i], HEX);
-        } 
-        Serial.println();
+    // Select one of the cards
+    if ( ! mfrc522.PICC_ReadCardSerial())
+        return;
 
-        // Dump PICC type
-        byte piccType = mfrc522.PICC_GetType(mfrc522.uid.sak);
-        Serial.print("PICC type: ");
-        Serial.println(mfrc522.PICC_GetTypeName(piccType));
-        if (        piccType != MFRC522::PICC_TYPE_MIFARE_MINI 
-                &&        piccType != MFRC522::PICC_TYPE_MIFARE_1K
-                &&        piccType != MFRC522::PICC_TYPE_MIFARE_4K) {
-                //Serial.println("This sample only works with MIFARE Classic cards.");
-                return;
-        }
-               
-        // In this sample we use the second sector (ie block 4-7). the first sector is = 0
-        // scegliere settore di lettura da 0 = primo settore 
-        byte sector         = 1;
-        // block sector 0-3(sector0) 4-7(sector1) 8-11(sector2)
-        // blocchi di scrittura da 0-3(sector0) 4-7(sector1) 8-11(sector2)
-        byte valueBlockA    = 4;
-        byte valueBlockB    = 5;
-        byte valueBlockC    = 6;
-        byte trailerBlock   = 7;
-        byte status;
-        // Authenticate using key A.
-        // avvio l'autentificazione A
-        //Serial.println("Authenticating using key A...");
-        status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
-        if (status != MFRC522::STATUS_OK) {
-                Serial.print("PCD_Authenticate() failed: ");
-                Serial.println(mfrc522.GetStatusCodeName(status));
-                return;
-        }
-        // Authenticate using key B.
-        // avvio l'autentificazione B
-        //Serial.println("Authenticating again using key B...");
-        status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_B, trailerBlock, &key, &(mfrc522.uid));
-        if (status != MFRC522::STATUS_OK) {
-                Serial.print("PCD_Authenticate() failed: ");
-                Serial.println(mfrc522.GetStatusCodeName(status));
-                return;
-        }
-        
-        // Writing new value block A
-        // Scrivo i valori per il settore A
-        Serial.println("Writing new value block A(4) : the first of the sector TWO ");
-                byte value1Block[] = { 1,2,3,4,  5,6,7,8, 9,10,255,12,  13,14,15,16,   valueBlockA,~valueBlockA,valueBlockA,~valueBlockA };
-                status = mfrc522.MIFARE_Write(valueBlockA, value1Block, 16);
-                if (status != MFRC522::STATUS_OK) {
-                        Serial.print("MIFARE_Write() failed: ");
-                        Serial.println(mfrc522.GetStatusCodeName(status));
-                }
-        /*
-        
-        // Writing new value block B
-        // Scrivo i valori per il settore B
-        Serial.println("Writing new value block B");
-                byte value2Block[] = { 255,255,255,255,  0,0,0,0, 0,0,0,0,  255,255,255,255,   valueBlockB,~valueBlockB,valueBlockB,~valueBlockB };
-                status = mfrc522.MIFARE_Write(valueBlockB, value2Block, 16);
-                if (status != MFRC522::STATUS_OK) {
-                        Serial.print("MIFARE_Write() failed: ");
-                        Serial.println(mfrc522.GetStatusCodeName(status));
-                }
-        
-        // Writing new value block D
-        // Scrivo i valori per il settore C
-        Serial.println("Writing new value block C");
-                byte value3Block[] = { 255,255,255,255,  0,0,0,0, 0,0,0,0,  255,255,255,255,   valueBlockC,~valueBlockC,valueBlockC,~valueBlockC };
-                status = mfrc522.MIFARE_Write(valueBlockC, value3Block, 16);
-                if (status != MFRC522::STATUS_OK) {
-                        Serial.print("MIFARE_Write() failed: ");
-                        Serial.println(mfrc522.GetStatusCodeName(status));
-                }
-                
-        */
-        
-        
-        Serial.println("Read block A(4) : the first of the sector TWO");        
-        byte buffer[18];
-        byte size = sizeof(buffer);
-        // change this: valueBlockA , for read anather block
-        // cambiate valueBlockA per leggere un altro blocco
-        status = mfrc522.MIFARE_Read(valueBlockA, buffer, &size);
-        Serial.print("Settore : 0 Valore :");
-        Serial.println(buffer[0]);
-        Serial.print("Settore : 1 Valore :");
-        Serial.println(buffer[1]);
-        Serial.print("Settore : 2 Valore :");
-        Serial.println(buffer[2]);
-        Serial.print("Settore : 3 Valore :");
-        Serial.println(buffer[3]);
-        Serial.print("Settore : 4 Valore :");
-        Serial.println(buffer[4]);
-        Serial.print("Settore : 5 Valore :");
-        Serial.println(buffer[5]);
-        Serial.print("Settore : 6 Valore :");
-        Serial.println(buffer[6]);
-        Serial.print("Settore : 7 Valore :");
-        Serial.println(buffer[7]);
-        Serial.print("Settore : 8 Valore :");
-        Serial.println(buffer[8]);
-        Serial.print("Settore : 9 Valore :");
-        Serial.println(buffer[9]);
-        Serial.print("Settore :10 Valore :");
-        Serial.println(buffer[10]);
-        Serial.print("Settore :11 Valore :");
-        Serial.println(buffer[11]);
-        Serial.print("Settore :12 Valore :");
-        Serial.println(buffer[12]);
-        Serial.print("Settore :13 Valore :");
-        Serial.println(buffer[13]);
-        Serial.print("Settore :14 Valore :");
-        Serial.println(buffer[14]);
-        Serial.print("Settore :15 Valore :");
-        Serial.println(buffer[15]);
-        
-        
-        
-        //byte value1Block[] = { 1,2,3,4,  5,6,7,8, 9,10,255,12,  13,14,15,16,   valueBlockA,~valueBlockA,valueBlockA,~valueBlockA };
-        if ( 
-        buffer[0]  == 1   &&
-        buffer[1]  == 2   && 
-        buffer[2]  == 3   && 
-        buffer[3]  == 4   &&
-        buffer[4]  == 5   &&
-        buffer[5]  == 6   &&
-        buffer[6]  == 7   &&
-        buffer[7]  == 8   &&
-        buffer[8]  == 9   &&
-        buffer[9]  == 10  &&
-        buffer[10] == 255 &&
-        buffer[11] == 12  &&
-        buffer[12] == 13  &&
-        buffer[13] == 14  &&
-        buffer[14] == 15  &&
-        buffer[15] == 16 
-        ){
-        
-        // sel a scrittura è uguale alla lettura allora e stato un successo !!   
-        Serial.println("Read block A(4) : the first of the sector TWO : success");  
-        Serial.println(":-)");  
-          
-        }else{
-        
-         //  scrittura Fallita
-        Serial.println("Read block A(4) : the first of the sector TWO : no match - write don't work fine ");
-        Serial.println(":-( ");  
-        
-        }
-        
-        
-        // risponde successo
-        //Serial.println(mfrc522.GetStatusCodeName(status));
-        
-        // Dump the result
-        //mfrc522.PICC_DumpMifareClassicSectorToSerial(&(mfrc522.uid), &key, sector);
-        
-        // Halt PICC
-        mfrc522.PICC_HaltA();
+    // Show some details of the PICC (that is: the tag/card)
+    Serial.print("Card UID:");
+    dump_byte_array(mfrc522.uid.uidByte, mfrc522.uid.size);
+    Serial.println();
+    Serial.print("PICC type: ");
+    byte piccType = mfrc522.PICC_GetType(mfrc522.uid.sak);
+    Serial.println(mfrc522.PICC_GetTypeName(piccType));
 
-        // Stop encryption on PCD
-        mfrc522.PCD_StopCrypto1();
+    // Check for compatibility
+    if (    piccType != MFRC522::PICC_TYPE_MIFARE_MINI
+        &&  piccType != MFRC522::PICC_TYPE_MIFARE_1K
+        &&  piccType != MFRC522::PICC_TYPE_MIFARE_4K) {
+        Serial.println("This sample only works with MIFARE Classic cards.");
+        return;
+    }
+
+    // In this sample we use the second sector,
+    // that is: sector #1, covering block #4 up to and including block #7
+    byte sector         = 1;
+    byte blockAddr      = 4;
+    byte dataBlock[]    = {
+        0x01, 0x02, 0x03, 0x04, //  1,  2,   3,  4,
+        0x05, 0x06, 0x07, 0x08, //  5,  6,   7,  8,
+        0x08, 0x09, 0xff, 0x0b, //  9, 10, 255, 12,
+        0x0c, 0x0d, 0x0e, 0x0f  // 13, 14,  15, 16
+    };
+    byte trailerBlock   = 7;
+    byte status;
+    byte buffer[18];
+    byte size = sizeof(buffer);
+
+    // Authenticate using key A
+    Serial.println("Authenticating using key A...");
+    status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
+    if (status != MFRC522::STATUS_OK) {
+        Serial.print("PCD_Authenticate() failed: ");
+        Serial.println(mfrc522.GetStatusCodeName(status));
+        return;
+    }
+
+    // Show the whole sector as it currently is
+    Serial.println("Current data in sector:");
+    mfrc522.PICC_DumpMifareClassicSectorToSerial(&(mfrc522.uid), &key, sector);
+    Serial.println();
+
+    // Read data from the block
+    Serial.print("Reading data from block "); Serial.print(blockAddr);
+    Serial.println(" ...");
+    status = mfrc522.MIFARE_Read(blockAddr, buffer, &size);
+    if (status != MFRC522::STATUS_OK) {
+        Serial.print("MIFARE_Read() failed: ");
+        Serial.println(mfrc522.GetStatusCodeName(status));
+    }
+    Serial.print("Data in block "); Serial.print(blockAddr); Serial.println(":");
+    dump_byte_array(buffer, 16); Serial.println();
+    Serial.println();
+
+    // Authenticate using key B
+    Serial.println("Authenticating again using key B...");
+    status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_B, trailerBlock, &key, &(mfrc522.uid));
+    if (status != MFRC522::STATUS_OK) {
+        Serial.print("PCD_Authenticate() failed: ");
+        Serial.println(mfrc522.GetStatusCodeName(status));
+        return;
+    }
+
+    // Write data to the block
+    Serial.print("Writing data into block "); Serial.print(blockAddr);
+    Serial.println(" ...");
+    dump_byte_array(dataBlock, 16); Serial.println();
+    status = mfrc522.MIFARE_Write(blockAddr, dataBlock, 16);
+    if (status != MFRC522::STATUS_OK) {
+        Serial.print("MIFARE_Write() failed: ");
+        Serial.println(mfrc522.GetStatusCodeName(status));
+    }
+    Serial.println();
+
+    // Read data from the block (again, should now be what we have written)
+    Serial.print("Reading data from block "); Serial.print(blockAddr);
+    Serial.println(" ...");
+    status = mfrc522.MIFARE_Read(blockAddr, buffer, &size);
+    if (status != MFRC522::STATUS_OK) {
+        Serial.print("MIFARE_Read() failed: ");
+        Serial.println(mfrc522.GetStatusCodeName(status));
+    }
+    Serial.print("Data in block "); Serial.print(blockAddr); Serial.println(":");
+    dump_byte_array(buffer, 16); Serial.println();
         
+    // Check that data in block is what we have written
+    // by counting the number of bytes that are equal
+    Serial.println("Checking result...");
+    byte count = 0;
+    for (byte i = 0; i < 16; i++) {
+        // Compare buffer (= what we've read) with dataBlock (= what we've written)
+        if (buffer[i] == dataBlock[i])
+            count++;
+    }
+    Serial.print("Number of bytes that match = "); Serial.println(count);
+    if (count == 16) {
+        Serial.println("Success :-)");
+    } else {
+        Serial.println("Failure, no match :-(");
+        Serial.println("  perhaps the write didn't work properly...");
+    }
+    Serial.println();
         
+    // Dump the sector data
+    Serial.println("Current data in sector:");
+    mfrc522.PICC_DumpMifareClassicSectorToSerial(&(mfrc522.uid), &key, sector);
+    Serial.println();
+
+    // Halt PICC
+    mfrc522.PICC_HaltA();
+    // Stop encryption on PCD
+    mfrc522.PCD_StopCrypto1();
+}
+
+/**
+ * Helper routine to dump a byte array as hex values to Serial.
+ */
+void dump_byte_array(byte *buffer, byte bufferSize) {
+    for (byte i = 0; i < bufferSize; i++) {
+        Serial.print(buffer[i] < 0x10 ? " 0" : " ");
+        Serial.print(buffer[i], HEX);
+    }
 }


### PR DESCRIPTION
Updated the `ReadAndWrite.ino` example sketch/program:
- Changed the description, to show that it is an example for the MFRC522 library
- Added link to the GitHub based project for the MFRC522 library
- Expanded the description of the example a little; including warning that data will be written
- Updated the pin layout based on #48 updated README
- Changed order (read, write, read/check) and added more comments to explain the process a little better
- Removed some stuff that had to do with value blocks, where this is just data in a block

Using block 4 in this example, in sector 1 (for this `ReadAndWrite.ino` example), which is compatible with the `MifareClassicValueBlock.ino` example (using block 5 and 6 of sector 1). Both examples use trailer block 7, though this `ReadAndWrite.ino` example is not trying to modify it.
