### PR TITLE
UID changeable card support

### DIFF
--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -1371,6 +1371,206 @@ void MFRC522::MIFARE_SetAccessBits(	byte *accessBitBuffer,	///< Pointer to byte 
 	accessBitBuffer[2] =          c3 << 4 | c2;
 } // End MIFARE_SetAccessBits()
 
+
+/**
+ * Performs the "magic sequence" needed to get Chinese UID changeable
+ * Mifare cards to allow writing to sector 0, where the card UID is stored.
+ *
+ * Note that you do not need to have selected the card through REQA or WUPA,
+ * this sequence works immediately when the card is in the reader vicinity.
+ * This means you can use this method even on "bricked" cards that your reader does
+ * not recognise anymore (see MFRC522::MIFARE_UnbrickUidSector).
+ * 
+ * Of course with non-bricked devices, you're free to select them before calling this function.
+ */
+bool MFRC522::MIFARE_OpenUidBackdoor(bool logErrors) {
+    // Magic sequence:
+    // > 50 00 57 CD (HALT + CRC)
+    // > 40 (7 bits only)
+    // < A (4 bits only)
+    // > 43
+    // < A (4 bits only)
+    // Then you can write to sector 0 without authenticating
+    
+    PICC_HaltA(); // 50 00 57 CD
+    
+    byte cmd = 0x40;
+    byte validBits = 7; /* Our command is only 7 bits. After receiving card response,
+                          this will contain amount of valid response bits. */
+    byte response[32]; // Card's response is written here
+    byte received;
+    byte status = PCD_TransceiveData(&cmd, (byte)1, response, &received, &validBits, (byte)0, false); // 40
+    if( status != STATUS_OK ) {
+        if( logErrors ) {
+            Serial.println("Card did not respond to 0x40 after HALT command. Are you sure it is a UID changeable one?");
+            Serial.print("Error name: ");
+            Serial.println(GetStatusCodeName(status));
+        }
+        return false;
+    }
+    if ( received != 1 || response[0] != 0x0A ) {
+        if ( logErrors ) {
+            Serial.print("Got bad response on backdoor 0x40 command: ");
+            Serial.print(response[0], HEX);
+            Serial.print(" (");
+            Serial.print(validBits);
+            Serial.print(" valid bits)\r\n");
+        }
+        return false;
+    }
+    
+    cmd = 0x43;
+    validBits = 8;
+    status = PCD_TransceiveData(&cmd, (byte)1, response, &received, &validBits, (byte)0, false); // 43
+    if( status != STATUS_OK ) {
+        if( logErrors ) {
+            Serial.println("Error in communication at command 0x43, after successfully executing 0x40");
+            Serial.print("Error name: ");
+            Serial.println(GetStatusCodeName(status));
+        }
+        return false;
+    }
+    if ( received != 1 || response[0] != 0x0A ) {
+        if ( logErrors ) {
+            Serial.print("Got bad response on backdoor 0x43 command: ");
+            Serial.print(response[0], HEX);
+            Serial.print(" (");
+            Serial.print(validBits);
+            Serial.print(" valid bits)\r\n");
+        }
+        return false;
+    }
+    
+    // You can now write to sector 0 without authenticating!
+    return true;
+} // End MIFARE_OpenUidBackdoor()
+
+/**
+ * Reads entire block 0, including all manufacturer data, and overwrites
+ * that block with the new UID, a freshly calculated BCC, and the original
+ * manufacturer data.
+ *
+ * It assumes a default KEY A of 0xFFFFFFFFFFFF.
+ * Make sure to have selected the card before this function is called.
+ */
+bool MFRC522::MIFARE_SetUid(byte* newUid, byte uidSize, bool logErrors) {
+    
+    // UID + BCC byte can not be larger than 16 together
+    if ( !newUid || !uidSize || uidSize > 15) {
+        if ( logErrors ) {
+            Serial.println("New UID buffer empty, size 0, or size > 15 given");
+        }
+        return false;
+    }
+    
+    // Authenticate for reading
+    MIFARE_Key key = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    byte status = PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, (byte)1, &key, &uid);
+    if ( status != STATUS_OK ) {
+        
+        if ( status == STATUS_TIMEOUT ) {
+            // We get a read timeout if no card is selected yet, so let's select one
+            
+            // Wake the card up again if sleeping
+//            byte atqa_answer[2];
+//            byte atqa_size = 2;
+//            PICC_WakeupA(atqa_answer, &atqa_size);
+            
+            if ( !PICC_IsNewCardPresent() || !PICC_ReadCardSerial() ) {
+                Serial.println("No card was previously selected, and none are available. Failed to set UID.");
+                return false;
+            }
+            
+            status = PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, (byte)1, &key, &uid);
+            if ( status != STATUS_OK ) {
+                // We tried, time to give up
+                if ( logErrors ) {
+                    Serial.println("Failed to authenticate to card for reading, could not set UID: ");
+                    Serial.println(GetStatusCodeName(status));
+                }
+                return false;
+            }
+        }
+        else {
+            if ( logErrors ) {
+                Serial.print("PCD_Authenticate() failed: ");
+                Serial.println(GetStatusCodeName(status));
+            }
+            return false;
+        }
+    }
+    
+    // Read block 0
+    byte block0_buffer[18];
+    byte byteCount = sizeof(block0_buffer);
+    status = MIFARE_Read((byte)0, block0_buffer, &byteCount);
+    if ( status != STATUS_OK ) {
+        if ( logErrors ) {
+            Serial.print("MIFARE_Read() failed: ");
+            Serial.println(GetStatusCodeName(status));
+            Serial.println("Are you sure your KEY A for sector 0 is 0xFFFFFFFFFFFF?");
+        }
+        return false;
+    }
+    
+    // Write new UID to the data we just read, and calculate BCC byte
+    byte bcc = 0;
+    for ( int i = 0; i < uidSize; i++ ) {
+        block0_buffer[i] = newUid[i];
+        bcc ^= newUid[i];
+    }
+    
+    // Write BCC byte to buffer
+    block0_buffer[uidSize] = bcc;
+    
+    // Stop encrypted traffic so we can send raw bytes
+    PCD_StopCrypto1();
+    
+    // Activate UID backdoor
+    if ( !MIFARE_OpenUidBackdoor(logErrors) ) {
+        if ( logErrors ) {
+            Serial.println("Activating the UID backdoor failed.");
+        }
+        return false;
+    }
+    
+    // Write modified block 0 back to card
+    status = MIFARE_Write((byte)0, block0_buffer, (byte)16);
+    if (status != STATUS_OK) {
+        if ( logErrors ) {
+            Serial.print("MIFARE_Write() failed: ");
+            Serial.println(GetStatusCodeName(status));
+        }
+        return false;
+    }
+    
+    // Wake the card up again
+    byte atqa_answer[2];
+    byte atqa_size = 2;
+    PICC_WakeupA(atqa_answer, &atqa_size);
+    
+    return true;
+}
+
+/**
+ * Resets entire sector 0 to zeroes, so the card can be read again by readers.
+ */
+bool MFRC522::MIFARE_UnbrickUidSector(bool logErrors) {
+    MIFARE_OpenUidBackdoor( logErrors );
+    
+    byte block0_buffer[] = {0x01, 0x02, 0x03, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    
+    // Write modified block 0 back to card
+    byte status = MIFARE_Write((byte)0, block0_buffer, (byte)16);
+    if (status != STATUS_OK) {
+        if ( logErrors ) {
+            Serial.print("MIFARE_Write() failed: ");
+            Serial.println(GetStatusCodeName(status));
+        }
+        return false;
+    }
+}
+
 /////////////////////////////////////////////////////////////////////////////////////
 // Convenience functions - does not add extra functionality
 /////////////////////////////////////////////////////////////////////////////////////

--- a/MFRC522.h
+++ b/MFRC522.h
@@ -3,6 +3,7 @@
  * Based on code Dr.Leong   ( WWW.B2CQSHOP.COM )
  * Created by Miguel Balboa (circuitito.com), Jan, 2012.
  * Rewritten by Søren Thing Andersen (access.thing.dk), fall of 2013 (Translation to English, refactored, comments, anti collision, cascade levels.)
+ * Extended by Tom Clement with functionality to write to sector 0 of UID changeable Mifare cards.
  * Released into the public domain.
  * 
  * Please read this file for an overview and then MFRC522.cpp for comments on the specific functions.
@@ -327,6 +328,9 @@ public:
 	void PICC_DumpMifareClassicSectorToSerial(Uid *uid, MIFARE_Key *key, byte sector);
 	void PICC_DumpMifareUltralightToSerial();
 	void MIFARE_SetAccessBits(byte *accessBitBuffer, byte g0, byte g1, byte g2, byte g3);
+    bool MIFARE_OpenUidBackdoor(bool logErrors);
+    bool MIFARE_SetUid(byte* newUid, byte uidSize, bool logErrors);
+    bool MIFARE_UnbrickUidSector(bool logErrors);
 	
 	/////////////////////////////////////////////////////////////////////////////////////
 	// Convenience functions - does not add extra functionality

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ Read and write different types of Radio-Frequency IDentification (RFID) cards
 on your Arduino using a RC522 based reader connected via the Serial Peripheral
 Interface (SPI) interface.
 
+Set the UID, write to sector 0, and unbrick Chinese UID changeable MIFARE cards.
+
 
 .. _pin layout:
 
@@ -97,6 +99,8 @@ for *"Arduino RFID module Kit 13.56 Mhz with Tags SPI W and R By COOQRobot"*.
 
 It was translated into English and rewritten/refactored in the fall of 2013
 by Søren Thing Andersen (from http://access.thing.dk).
+
+It has been extended with functionality to alter sector 0 on Chinese UID changeable MIFARE card in Oct 2014 by Tom Clement (from http://tomclement.nl).
 
 
 .. _arduino: http://arduino.cc/

--- a/examples/ChangeUID/ChangeUID.ino
+++ b/examples/ChangeUID/ChangeUID.ino
@@ -1,0 +1,122 @@
+/*
+ * MFRC522 - Library to use ARDUINO RFID MODULE KIT 13.56 MHZ WITH TAGS SPI W AND R BY COOQROBOT.
+ * The library file MFRC522.h has a wealth of useful info. Please read it.
+ * The functions are documented in MFRC522.cpp.
+ *
+ * Based on code Dr.Leong   ( WWW.B2CQSHOP.COM )
+ * Created by Miguel Balboa (circuitito.com), Jan, 2012.
+ * Rewritten by Søren Thing Andersen (access.thing.dk), fall of 2013 (Translation to English, refactored, comments, anti collision, cascade levels.)
+ * Extended by Tom Clement with functionality to write to sector 0 of UID changeable Mifare cards.
+ * 
+ * Released into the public domain.
+ *
+ * This sample shows how to setup a block on a MIFARE Classic PICC to be in "Value Block" mode.
+ * In Value Block mode the operations Increment/Decrement/Restore and Transfer can be used.
+ * 
+ ----------------------------------------------------------------------------- empty_skull 
+ 
+ - Aggiunti pin per arduino Mega
+ - Scritto semplice codice per la scrittura e lettura 
+ 
+ - add pin configuration for arduino mega
+ - write simple read/write Code for new entry user
+ 
+ http://mac86project.altervista.org/
+ 
+ ----------------------------------------------------------------------------- Nicola Coppola
+ * Pin layout should be as follows:
+ * Signal     Pin              Pin               Pin
+ *            Arduino Uno      Arduino Mega      MFRC522 board
+ * ------------------------------------------------------------
+ * Reset      9                5                 RST
+ * SPI SS     10               53                SDA
+ * SPI MOSI   11               51                MOSI
+ * SPI MISO   12               50                MISO
+ * SPI SCK    13               52                SCK
+ *
+ * The reader can be found on eBay for around 5 dollars. Search for "mf-rc522" on ebay.com. 
+ */
+
+#include <SPI.h>
+#include <MFRC522.h>
+
+/* Set your new UID here! */
+#define NEW_UID {0xDE, 0xAD, 0xBE, 0xEF}
+#define SS_PIN 10
+#define RST_PIN 9
+
+MFRC522 mfrc522(SS_PIN, RST_PIN);        // Create MFRC522 instance.
+MFRC522::MIFARE_Key key;
+
+void setup() {
+        Serial.begin(9600);        // Initialize serial communications with the PC
+        SPI.begin();                // Init SPI bus
+        mfrc522.PCD_Init();        // Init MFRC522 card
+        Serial.println("Warning: this example overwrites the UID of your UID changeable card, use with care!");
+        
+        // Prepare key - all keys are set to FFFFFFFFFFFFh at chip delivery from the factory.
+        for (byte i = 0; i < 6; i++) {
+                key.keyByte[i] = 0xFF;
+        }
+}
+
+// Setting the UID can be as simple as this:
+//void loop() {
+//    byte newUid[] = NEW_UID;
+//    if ( mfrc522.MIFARE_SetUid(newUid, (byte)4, true) ) {
+//      Serial.println("Wrote new UID to card.");
+//    }
+//    delay(1000);
+//}
+
+// But of course this is a more proper approach
+void loop() {
+  
+        // Look for new cards, and select one if present
+        if ( ! mfrc522.PICC_IsNewCardPresent() || ! mfrc522.PICC_ReadCardSerial() ) {
+            delay(50);
+            return;
+        }
+        
+        // Now a card is selected. The UID and SAK is in mfrc522.uid.
+        
+        // Dump UID
+        Serial.print("Card UID:");
+        for (byte i = 0; i < mfrc522.uid.size; i++) {
+                Serial.print(mfrc522.uid.uidByte[i] < 0x10 ? " 0" : " ");
+                Serial.print(mfrc522.uid.uidByte[i], HEX);
+        } 
+        Serial.println();
+
+        // Dump PICC type
+//        byte piccType = mfrc522.PICC_GetType(mfrc522.uid.sak);
+//        Serial.print("PICC type: ");
+//        Serial.print(mfrc522.PICC_GetTypeName(piccType));
+//        Serial.print(" (SAK ");
+//        Serial.print(mfrc522.uid.sak);
+//        Serial.print(")\r\n");
+//        if (        piccType != MFRC522::PICC_TYPE_MIFARE_MINI 
+//                &&        piccType != MFRC522::PICC_TYPE_MIFARE_1K
+//                &&        piccType != MFRC522::PICC_TYPE_MIFARE_4K) {
+//                Serial.println("This sample only works with MIFARE Classic cards.");
+//                return;
+//        }
+        
+        // Set new UID
+        byte newUid[] = NEW_UID;
+        if ( mfrc522.MIFARE_SetUid(newUid, (byte)4, true) ) {
+            Serial.println("Wrote new UID to card.");
+        }
+        
+        // Halt PICC and re-select it so DumpToSerial doesn't get confused
+        mfrc522.PICC_HaltA();
+        if ( ! mfrc522.PICC_IsNewCardPresent() || ! mfrc522.PICC_ReadCardSerial() ) {
+                return;
+        }
+        
+        // Dump the new memory contents
+        Serial.println("New UID and contents:");
+        mfrc522.PICC_DumpToSerial(&(mfrc522.uid));
+        
+        delay(2000);
+}

--- a/examples/ChangeUID/ChangeUID.ino
+++ b/examples/ChangeUID/ChangeUID.ino
@@ -10,8 +10,7 @@
  * 
  * Released into the public domain.
  *
- * This sample shows how to setup a block on a MIFARE Classic PICC to be in "Value Block" mode.
- * In Value Block mode the operations Increment/Decrement/Restore and Transfer can be used.
+ * This sample shows how to set the UID on a UID changeable MIFARE card.
  * 
  ----------------------------------------------------------------------------- empty_skull 
  

--- a/examples/FixBrickedUID/FixBrickedUID.ino
+++ b/examples/FixBrickedUID/FixBrickedUID.ino
@@ -1,0 +1,65 @@
+/*
+ * MFRC522 - Library to use ARDUINO RFID MODULE KIT 13.56 MHZ WITH TAGS SPI W AND R BY COOQROBOT.
+ * The library file MFRC522.h has a wealth of useful info. Please read it.
+ * The functions are documented in MFRC522.cpp.
+ *
+ * Based on code Dr.Leong   ( WWW.B2CQSHOP.COM )
+ * Created by Miguel Balboa (circuitito.com), Jan, 2012.
+ * Rewritten by Søren Thing Andersen (access.thing.dk), fall of 2013 (Translation to English, refactored, comments, anti collision, cascade levels.)
+ * Extended by Tom Clement with functionality to write to sector 0 of UID changeable Mifare cards.
+ * 
+ * Released into the public domain.
+ *
+ * This sample shows how to fix a UID changeable MIFARE cards that have a corrupted sector 0.
+ * 
+ ----------------------------------------------------------------------------- empty_skull 
+ 
+ - Aggiunti pin per arduino Mega
+ - Scritto semplice codice per la scrittura e lettura 
+ 
+ - add pin configuration for arduino mega
+ - write simple read/write Code for new entry user
+ 
+ http://mac86project.altervista.org/
+ 
+ ----------------------------------------------------------------------------- Nicola Coppola
+ * Pin layout should be as follows:
+ * Signal     Pin              Pin               Pin
+ *            Arduino Uno      Arduino Mega      MFRC522 board
+ * ------------------------------------------------------------
+ * Reset      9                5                 RST
+ * SPI SS     10               53                SDA
+ * SPI MOSI   11               51                MOSI
+ * SPI MISO   12               50                MISO
+ * SPI SCK    13               52                SCK
+ *
+ * The reader can be found on eBay for around 5 dollars. Search for "mf-rc522" on ebay.com. 
+ */
+
+#include <SPI.h>
+#include <MFRC522.h>
+
+#define SS_PIN 10
+#define RST_PIN 9
+
+MFRC522 mfrc522(SS_PIN, RST_PIN);        // Create MFRC522 instance.
+MFRC522::MIFARE_Key key;
+
+void setup() {
+        Serial.begin(9600);        // Initialize serial communications with the PC
+        SPI.begin();                // Init SPI bus
+        mfrc522.PCD_Init();        // Init MFRC522 card
+        Serial.println("Warning: this example clears your mifare UID, use with care!");
+        
+        // Prepare key - all keys are set to FFFFFFFFFFFFh at chip delivery from the factory.
+        for (byte i = 0; i < 6; i++) {
+                key.keyByte[i] = 0xFF;
+        }
+}
+
+void loop() {
+    if ( mfrc522.MIFARE_UnbrickUidSector(false) ) {
+      Serial.println("Cleared sector 0, set UID to 1234. Card should be responsive again now.");
+    }
+    delay(1000);
+}


### PR DESCRIPTION
Now supports writing to sector 0, which means changing the card's UID, writing to the manufacturers section, and unbricking bricked cards.

Requires a Chinese UID changeable card.