### PR TITLE
Added clearing 8 bit in sak PICC_GetType

### DIFF
--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -1177,7 +1177,7 @@ byte MFRC522::PICC_GetType(byte sak		///< The SAK byte returned from PICC_Select
 	}
 	//http://www.nxp.com/documents/application_note/AN10833.pdf 
 	//3.2 Coding of Select Acknowledge (SAK)
-	//ignore 7-bit
+	//ignore 8-bit
 	sak&=0x7F;
 	switch (sak) {
 		case 0x09:	return PICC_TYPE_MIFARE_MINI;	break;

--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -1175,7 +1175,10 @@ byte MFRC522::PICC_GetType(byte sak		///< The SAK byte returned from PICC_Select
 	if (sak & 0x04) { // UID not complete
 		return PICC_TYPE_NOT_COMPLETE;
 	}
-	
+	//http://www.nxp.com/documents/application_note/AN10833.pdf 
+	//3.2 Coding of Select Acknowledge (SAK)
+	//ignore 7-bit
+	sak&=0x7F;
 	switch (sak) {
 		case 0x09:	return PICC_TYPE_MIFARE_MINI;	break;
 		case 0x08:	return PICC_TYPE_MIFARE_1K;		break;


### PR DESCRIPTION
Hello, some cards have setted high bit (8) to 1 so code in PICC_GetType cant detect it correctly.
For example i have card (MIFARE 1KB) with SAK = 0x88


See for example:
http://www.nxp.com/documents/application_note/AN10833.pdf 
3.2 Coding of Select Acknowledge (SAK)