### PR TITLE
Upd readme & fix compile error

### DIFF
--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -1769,7 +1769,7 @@ bool MFRC522::PICC_ReadCardSerial() {
 	return (result == STATUS_OK);
 } // End 
 
-PICC_ReadCardSerial()MFRC522::StatusCode MFRC522::PCD_NTAG216_AUTH(byte *passWord, byte pACK[]) //Authenticate with 32bit password
+MFRC522::StatusCode MFRC522::PCD_NTAG216_AUTH(byte *passWord, byte pACK[]) //Authenticate with 32bit password
 {
   MFRC522::StatusCode result;
   byte cmdBuffer[18]; // We need room for 16 bytes data and 2 bytes CRC_A.

--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -1110,6 +1110,49 @@ MFRC522::StatusCode MFRC522::MIFARE_SetValue(byte blockAddr, long value) {
 	return MIFARE_Write(blockAddr, buffer, 16);
 } // End MIFARE_SetValue()
 
+/**
+ * Authenticate with a NTAG216.
+ * 
+ * Only for NTAG216. First implemented by Gargantuanman.
+ * 
+ * @param[in]   passWord   password.
+ * @param[in]   pACK       result success???.
+ * @return STATUS_OK on success, STATUS_??? otherwise.
+ */
+MFRC522::StatusCode MFRC522::PCD_NTAG216_AUTH(byte* passWord, byte pACK[]) //Authenticate with 32bit password
+{
+	MFRC522::StatusCode result;
+	byte				cmdBuffer[18]; // We need room for 16 bytes data and 2 bytes CRC_A.
+	
+	cmdBuffer[0] = 0x1B; //Comando de autentificacion
+	
+	for (byte i = 0; i<4; i++)
+		cmdBuffer[i+1] = passWord[i];
+	
+	result = PCD_CalculateCRC(cmdBuffer, 5, &cmdBuffer[5]);
+	
+	if (result!=STATUS_OK) {
+		return result;
+	}
+	
+	// Transceive the data, store the reply in cmdBuffer[]
+	byte waitIRq		= 0x30;	// RxIRq and IdleIRq
+	byte cmdBufferSize	= sizeof(cmdBuffer);
+	byte validBits		= 0;
+	byte rxlength		= 5;
+	result = PCD_CommunicateWithPICC(PCD_Transceive, waitIRq, cmdBuffer, 7, cmdBuffer, &rxlength, &validBits);
+	
+	pACK[0] = cmdBuffer[0];
+	pACK[1] = cmdBuffer[1];
+	
+	if (result!=STATUS_OK) {
+		return result;
+	}
+	
+	return STATUS_OK;
+} // End PCD_NTAG216_AUTH()
+
+
 /////////////////////////////////////////////////////////////////////////////////////
 // Support functions
 /////////////////////////////////////////////////////////////////////////////////////
@@ -1768,36 +1811,3 @@ bool MFRC522::PICC_ReadCardSerial() {
 	byte result = PICC_Select(&uid);
 	return (result == STATUS_OK);
 } // End 
-
-MFRC522::StatusCode MFRC522::PCD_NTAG216_AUTH(byte *passWord, byte pACK[]) //Authenticate with 32bit password
-{
-  MFRC522::StatusCode result;
-  byte cmdBuffer[18]; // We need room for 16 bytes data and 2 bytes CRC_A.
-
-cmdBuffer[0] = 0x1B; //Comando de autentificacion
-
- for(byte i = 0; i < 4; i++)
-	cmdBuffer[i + 1] = passWord[i];
-
-  result = PCD_CalculateCRC(cmdBuffer, 5, &cmdBuffer[5]);
-
-  if (result != STATUS_OK) {
-    return result;
-  }
-
-  // Transceive the data, store the reply in cmdBuffer[]
-  byte waitIRq = 0x30;    // RxIRq and IdleIRq
-  byte cmdBufferSize = sizeof(cmdBuffer);
-  byte validBits = 0;
-byte rxlength = 5;
-  result = PCD_CommunicateWithPICC(PCD_Transceive, waitIRq, cmdBuffer, 7, cmdBuffer, &rxlength, &validBits);
-
-pACK[0] = cmdBuffer[0];
-pACK[1] = cmdBuffer[1];
-
-  if (result != STATUS_OK) {
-    return result;
-  }
-
-  return STATUS_OK;
-}

--- a/MFRC522.h
+++ b/MFRC522.h
@@ -373,7 +373,6 @@ public:
 	MFRC522::StatusCode MIFARE_GetValue(byte blockAddr, long *value);
 	MFRC522::StatusCode MIFARE_SetValue(byte blockAddr, long value);
 	MFRC522::StatusCode PCD_NTAG216_AUTH(byte *passWord, byte pACK[]);
-
 	
 	/////////////////////////////////////////////////////////////////////////////////////
 	// Support functions

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ There are three hardware components involved:
 * One or two might be included with the Reader or *"starter kit"* already.
 
 
+.. _protocol:
 Protocols
 ---------
 
@@ -95,6 +96,14 @@ Protocols
   * The reader do not support ISO/IEC 14443-3 Type B.
 
 
+.. _security:
+Security
+-------
+This library only supports crypto1-encrypted communication. Crypto1 is for a few years `broken`_. So it do NOT offer ANY security, it is like a unencrypted communication. **Do not use it for any security related application!**
+This library do not offer 3DES or AES authentification used by e.g. Mifare DESFire, maybe it can be implemented because the datasheet says there ist a support. We hope for pull requests :).
+
+
+.. _troubleshooting:
 Troubleshooting
 -------
 
@@ -103,6 +112,7 @@ Troubleshooting
   #. Check your connection, see `Pin Layout`_ .
   #. Check voltage. Most breakouts work with 3.3V.
   #. The SPI only works with 3.3V, most breakouts seems 5V tollerant, but try a level shifter.
+  #. According to reports #101, #126, #131 there are maybe a problem with the soldering on the MFRC522 breakout. You maybe can fix it by your own.
 
 
 * **Sometimes I get timeouts** or **tag/card sometimes not work.**
@@ -112,8 +122,8 @@ Troubleshooting
   #. Increase antenna gain per firmware: ``mfrc522.PCD_SetAntennaGain(mfrc522.RxGain_max);``
   #. Use better power supply.
   #. Hardware corrupted, most products are from china and sometimes the quality is really low. Contact your seller.
-  
-  
+
+
 * **My tag/card doesn't work.**
   
   #. Distance between antenna and token too huge (>1cm).
@@ -121,19 +131,21 @@ Troubleshooting
   #. NFC tokens are not supported. Some may work.
   #. Animal marker are not supported. They use other frequency.
   #. Hardware corrupted, most products are from china and sometimes the quality is really low. Contact your seller.
+  #. Newer versions of Mifare cards like DESFire/Ultralight maybe not work according to missing authentification, see `security`_ or different `protocol`_.
 
 * **My mobile phone doesn't recognize the MFRC522** or **my MFRC522 can't read data from other MFRC522**
 
   #. Card simmulation is not supported.
   #. Communication with mobile phones is not supported.
   #. Peer to peer communication is not supported.
-  
+
+
 * **I need more features.**
 
   #. If software: code it and make a pull request.
   #. If hardware: buy a more expensive like PN532 (supports NFC and many more, but costs about $15)
-  
-  
+
+
 License
 -------
 This is free and unencumbered software released into the public domain.
@@ -175,8 +187,9 @@ by Søren Thing Andersen (from http://access.thing.dk).
 It has been extended with functionality to alter sector 0 on Chinese UID changeable MIFARE card in Oct 2014 by Tom Clement (from http://tomclement.nl).
 
 
-.. _arduino: http://arduino.cc/
+.. _arduino: https://arduino.cc/
 .. _ebay: http://www.ebay.com/
-.. _iso/iec 14443a: http://en.wikipedia.org/wiki/ISO/IEC_14443
+.. _iso/iec 14443a: https://en.wikipedia.org/wiki/ISO/IEC_14443
 .. _iso/iec 14443-3\:2011 part 3: 
 .. _nxp mfrc522: http://www.nxp.com/documents/data_sheet/MFRC522.pdf
+.. _broken: http://eprint.iacr.org/2008/166

--- a/examples/Ntag216_AUTH/Ntag216_AUTH.ino
+++ b/examples/Ntag216_AUTH/Ntag216_AUTH.ino
@@ -1,11 +1,11 @@
 //This example show how you can get Authenticated by the NTAG213,215,216 by default the tags are unprotected in order to protect them we need to write 4 different values:
-// Using mfrc522.MIFARE_Ultralight_Write(PageNum, Data, #Databytes)) 
+// Using mfrc522.MIFARE_Ultralight_Write(PageNum, Data, #Databytes))
 //1.- we need to write the 32bit passWord to page 0xE5 !for ntag 213 and 215 page is different refer to nxp documentation!
 //2.- Now Write the 16 bits pACK to the page 0xE6 use the 2 high bytes like this: pACKH + pACKL + 00 + 00 after an authentication the tag will return this secret bytes
 //3.- Now we need to write the first page we want to protect this is a 1 byte data in page 0xE3 we need to write 00 + 00 + 00 + firstPage  all pages after this one are write protected
 // Now WRITE protection is ACTIVATED so we need to get authenticated in order to write the last data
 //4.- Finally we need to write an access record in order to READ protect the card this step is optional only if you want to read protect also write 80 + 00 + 00 + 00 to 0xE4
-//After completeing all these steps you will nee to authentiate first in order to read or write ant page after the first page you selected to protect 
+//After completeing all these steps you will nee to authentiate first in order to read or write ant page after the first page you selected to protect
 //To disengage proection just write the page (0xE3) to 00 + 00 + 00 + FF that going to remove all protection
 //Made by GARGANTUA from RoboCreators.com & paradoxalabs.com
 
@@ -36,24 +36,23 @@ void loop() {
     return;
   }
 
+  byte PSWBuff[] = {0xFF, 0xFF, 0xFF, 0xFF}; //32 bit PassWord default FFFFFFFF
+  byte pACK[] = {0, 0}; //16 bit PassWord ACK returned by the NFCtag
 
-byte PSWBuff[]={0xFF,0xFF,0xFF,0xFF}; //32 bit PassWord default FFFFFFFF
-byte pACK[]={0,0}; //16 bit PassWord ACK returned by the NFCtag
+  Serial.print("Auth: ");
+  Serial.println(mfrc522.PCD_NTAG216_AUTH(&PSWBuff[0], pACK)); //Request Authentification if return STATUS_OK we are good
 
-Serial.print("Auth: ");
-Serial.println(mfrc522.PCD_NTAG216_AUTH(&PSWBuff[0],pACK)); //Request Authentification if return STATUS_OK we are good
+  //Print PassWordACK
+  Serial.print(pACK[0], HEX);
+  Serial.println(pACK[1], HEX);
 
-//Print PassWordACK
-Serial.print(pACK[0],HEX);
-Serial.println(pACK[1],HEX);
+  byte WBuff[] = {0x00, 0x00, 0x00, 0x04};
+  byte RBuff[18];
 
-byte WBuff[] = {0x00,0x00,0x00,0x04};
-byte RBuff[18];
+  //Serial.print("CHG BLK: ");
+  //Serial.println(mfrc522.MIFARE_Ultralight_Write(0xE3, WBuff, 4));  //How to write to a page
 
-//Serial.print("CHG BLK: ");
-//Serial.println(mfrc522.MIFARE_Ultralight_Write(0xE3, WBuff, 4));  //How to write to a page 
-    
-mfrc522.PICC_DumpMifareUltralightToSerial(); //This is a modifier dunp just cghange the for cicle to < 232 instead of < 16 in order to see all the pages on NTAG216
+  mfrc522.PICC_DumpMifareUltralightToSerial(); //This is a modifier dunp just cghange the for cicle to < 232 instead of < 16 in order to see all the pages on NTAG216
 
-delay(3000);
+  delay(3000);
 }

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,9 @@
 name=MFRC522
-#date as version - no leading zero
-version=2015.9.4
+version=1.1.2
 author=GithubCommunity
 maintainer=miguelbalboa
 sentence=Arduino RFID Library for MFRC522 (SPI)
 paragraph=Read/Write a RFID Card or Tag using the ISO/IEC 14443A/MIFARE interface.
 category=Communication
 url=https://github.com/miguelbalboa/rfid
-architectures=avr,STM32F1
+architectures=avr,STM32F1,teensy


### PR DESCRIPTION
Hi,
due a lession on the 32c3, I added a security hint in the readme. ;)
The merge of ntag216 auth broke code, fixed it and add small comment and moved it to the obvious position in code.
Nice that you use now releases, may renew release or bump to new version.

BTW happy new year :)