### PR TITLE
Half-way interrupt-based reader

### DIFF
--- a/examples/Minimalnterrupt/rfidIntMin.ino
+++ b/examples/Minimalnterrupt/rfidIntMin.ino
@@ -1,0 +1,137 @@
+/**
+ * ----------------------------------------------------------------------------
+ * This is a MFRC522 library example; see https://github.com/miguelbalboa/rfid
+ * for further details and other examples.
+ * 
+ * NOTE: The library file MFRC522.h has a lot of useful info. Please read it.
+ * 
+ * Released into the public domain.
+ * ----------------------------------------------------------------------------
+ * Minimal example how to use the interrupts to read the UID of a MIFARE Classic PICC
+ * (= card/tag).
+ * 
+ * 
+ * Typical pin layout used:
+ * -----------------------------------------------------------------------------------------
+ *             MFRC522      Arduino       Arduino   Arduino    Arduino          Arduino
+ *             Reader/PCD   Uno           Mega      Nano v3    Leonardo/Micro   Pro Micro
+ * Signal      Pin          Pin           Pin       Pin        Pin              Pin
+ * -----------------------------------------------------------------------------------------
+ * RST/Reset   RST          9             5         D9         RESET/ICSP-5     RST
+ * SPI SS      SDA(SS)      10            53        D10        3                10
+ * IRQ         ?            ?             ?         ?          2                10
+ * SPI MOSI    MOSI         11 / ICSP-4   51        D11        ICSP-4           16
+ * SPI MISO    MISO         12 / ICSP-1   50        D12        ICSP-1           14
+ * SPI SCK     SCK          13 / ICSP-3   52        D13        ICSP-3           15
+ * 
+ */
+
+#include <SPI.h>
+#include <MFRC522.h>
+
+#define RST_PIN         9           // Configurable, see typical pin layout above
+#define SS_PIN          3           // Configurable, see typical pin layout above
+#define IRQ_PIN         2           
+
+MFRC522 mfrc522(SS_PIN, RST_PIN);   // Create MFRC522 instance.
+
+MFRC522::MIFARE_Key key;
+
+volatile boolean bNewInt = false;
+unsigned char regVal = 0x7F;
+void activateRec(MFRC522 mfrc522);
+void clearInt(MFRC522 mfrc522);
+
+/**
+ * Initialize.
+ */
+void setup() {
+    Serial.begin(115200); // Initialize serial communications with the PC
+    while (!Serial);    // Do nothing if no serial port is opened (added for Arduinos based on ATMEGA32U4)
+    SPI.begin();        // Init SPI bus
+    
+    mfrc522.PCD_Init(); // Init MFRC522 card
+
+    /* read and printout the MFRC522 version (valid values 0x91 & 0x92)*/
+    Serial.print("Ver: 0x");      
+    byte readReg = mfrc522.PCD_ReadRegister(mfrc522.VersionReg);
+    Serial.println(readReg, HEX);      
+
+     /* setup the IRQ pin*/ 
+    pinMode(IRQ_PIN, INPUT_PULLUP);
+   
+    /* 
+     *  Allow the ... irq to be propagated to the IRQ pin
+     *  For test purposes propagate the IdleIrq and loAlert
+     */
+    regVal = 0xA0; //rx irq
+    mfrc522.PCD_WriteRegister(mfrc522.ComIEnReg,regVal);
+    
+    bNewInt = false; //interrupt flag
+
+    /*Activate the interrupt*/
+    attachInterrupt(digitalPinToInterrupt(IRQ_PIN), readCard, FALLING);
+
+    Serial.println("End setup"); 
+
+    do{ //clear a spourious interrupt at start
+      ;
+    }while(!bNewInt);
+    bNewInt = false;
+}
+
+/**
+ * Main loop.
+ */
+void loop() {
+   
+   if(bNewInt){  //new read interrupt
+      bNewInt = false;
+      Serial.print("Interrupt. ");
+      mfrc522.PICC_ReadCardSerial(); //read the tag data
+      // Show some details of the PICC (that is: the tag/card)
+      Serial.print(F("Card UID:"));
+      dump_byte_array(mfrc522.uid.uidByte, mfrc522.uid.size);
+      Serial.println();
+     
+      clearInt(mfrc522);
+   }
+
+// The receiving block needs regular retriggering (tell the tag it should transmit??)
+// (mfrc522.PCD_WriteRegister(mfrc522.FIFODataReg,mfrc522.PICC_CMD_REQA);)
+   activateRec(mfrc522);
+   delay(100);
+} //loop()
+
+/**
+ * Helper routine to dump a byte array as hex values to Serial.
+ */
+void dump_byte_array(byte *buffer, byte bufferSize) {
+    for (byte i = 0; i < bufferSize; i++) {
+        Serial.print(buffer[i] < 0x10 ? " 0" : " ");
+        Serial.print(buffer[i], HEX);
+    }
+}
+/**
+ * MFRC522 interrupt serving routine
+ */
+void readCard(){
+   bNewInt = true;
+}
+
+/*
+ * The function sending to the MFRC522 the needed commands to activate the reception
+ */
+void activateRec(MFRC522 mfrc522){
+    mfrc522.PCD_WriteRegister(mfrc522.FIFODataReg,mfrc522.PICC_CMD_REQA);
+    mfrc522.PCD_WriteRegister(mfrc522.CommandReg,mfrc522.PCD_Transceive);  
+    mfrc522.PCD_WriteRegister(mfrc522.BitFramingReg, 0x87);    
+}
+
+/*
+ * The function to clear the pending interrupt bits after interrupt serving routine
+ */
+void clearInt(MFRC522 mfrc522){
+   mfrc522.PCD_WriteRegister(mfrc522.ComIrqReg,0x7F);
+}
+


### PR DESCRIPTION
Hello all,

These days I've had some success implementing an interrupt-based system.
As the title says, it is only a "half-way" one, because it seems the tags need to be "activated" *) before they send data (PICC_CMD_REQA command).
That means, I'm sending the tag "activation" instructions in a "polling" way, and I'm reading the data only when an interrupt is triggered. 
I hope someone will find my "discovery" useful. I also hope someone will succeed to implement a "full-interrupt" system.

*) At least it is the explanation I found for the reader behavior. 

Best regards,
Liviu