### PR TITLE
Fix MinimalInterrupt example

### DIFF
--- a/examples/MinimalInterrupt/MinimalInterrupt.ino
+++ b/examples/MinimalInterrupt/MinimalInterrupt.ino
@@ -76,7 +76,7 @@ void setup() {
 
     do{ //clear a spourious interrupt at start
       ;
-    }while(!bNewInt);
+    }while(bNewInt);
     bNewInt = false;
 }
 
@@ -95,6 +95,7 @@ void loop() {
       Serial.println();
      
       clearInt(mfrc522);
+      mfrc522.PICC_HaltA();
    }
 
 // The receiving block needs regular retriggering (tell the tag it should transmit??)


### PR DESCRIPTION
I found two issues while testing on my NodeMCU 1.0:

- Loop to "clear a spourious interrupt at start" was infinite. A "sporious interrupt" should make bNewInt true, not false.

- When card is detected, PICC should be halted to prevent continuous interruption.