### PR TITLE
Added support for PIC32 return types

### DIFF
--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -1205,7 +1205,7 @@ MFRC522::StatusCode MFRC522::PCD_MIFARE_Transceive(	byte *sendData,		///< Pointe
  * 
  * @return const __FlashStringHelper *
  */
-const __FlashStringHelper *MFRC522::GetStatusCodeName(MFRC522::StatusCode code	///< One of the StatusCode enums.
+CCRET *MFRC522::GetStatusCodeName(MFRC522::StatusCode code	///< One of the StatusCode enums.
 										) {
 	switch (code) {
 		case STATUS_OK:				return F("Success.");
@@ -1253,7 +1253,7 @@ MFRC522::PICC_Type MFRC522::PICC_GetType(byte sak		///< The SAK byte returned fr
  * 
  * @return const __FlashStringHelper *
  */
-const __FlashStringHelper *MFRC522::PICC_GetTypeName(PICC_Type piccType	///< One of the PICC_Type enums.
+CCRET *MFRC522::PICC_GetTypeName(PICC_Type piccType	///< One of the PICC_Type enums.
 													) {
 	switch (piccType) {
 		case PICC_TYPE_ISO_14443_4:		return F("PICC compliant with ISO/IEC 14443-4");

--- a/MFRC522.h
+++ b/MFRC522.h
@@ -78,6 +78,12 @@
 #include <Arduino.h>
 #include <SPI.h>
 
+#ifdef __PIC32__
+#define CCRET const char
+#else
+#define CCRET const __FlashStringHelper
+#endif
+
 // Firmware data for self-test
 // Reference values based on firmware version
 // Hint: if needed, you can remove unused self-test data to save flash memory
@@ -381,11 +387,11 @@ public:
 	StatusCode PCD_MIFARE_Transceive(byte *sendData, byte sendLen, bool acceptTimeout = false);
 	// old function used too much memory, now name moved to flash; if you need char, copy from flash to memory
 	//const char *GetStatusCodeName(byte code);
-	static const __FlashStringHelper *GetStatusCodeName(StatusCode code);
+	static CCRET *GetStatusCodeName(StatusCode code);
 	static PICC_Type PICC_GetType(byte sak);
 	// old function used too much memory, now name moved to flash; if you need char, copy from flash to memory
 	//const char *PICC_GetTypeName(byte type);
-	static const __FlashStringHelper *PICC_GetTypeName(PICC_Type type);
+	static CCRET *PICC_GetTypeName(PICC_Type type);
 	
 	// Support functions for debuging
 	void PCD_DumpVersionToSerial();


### PR DESCRIPTION
This simply abstracts `const __FlashStringHelper` or `const char` into a macro `CCRET` (Const Char RETurn) chosen by the existence of the macro `__PIC32__` so the library works properly with the chipKIT system.