### PR TITLE
Get SPI SS/CS pin automatically

### DIFF
--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -20,6 +20,14 @@ MFRC522::MFRC522() {
  * Constructor.
  * Prepares the output pins.
  */
+MFRC522::MFRC522(	byte resetPowerDownPin	///< Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
+				): MFRC522(SS, resetPowerDownPin) {
+} // End constructor
+
+/**
+ * Constructor.
+ * Prepares the output pins.
+ */
 MFRC522::MFRC522(	byte chipSelectPin,		///< Arduino pin connected to MFRC522's SPI slave select input (Pin 24, NSS, active low)
 					byte resetPowerDownPin	///< Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
 				) {
@@ -215,6 +223,14 @@ void MFRC522::PCD_Init() {
 	PCD_WriteRegister(TxASKReg, 0x40);		// Default 0x00. Force a 100 % ASK modulation independent of the ModGsPReg register setting
 	PCD_WriteRegister(ModeReg, 0x3D);		// Default 0x3F. Set the preset value for the CRC coprocessor for the CalcCRC command to 0x6363 (ISO 14443-3 part 6.2.4)
 	PCD_AntennaOn();						// Enable the antenna driver pins TX1 and TX2 (they were disabled by the reset)
+} // End PCD_Init()
+
+/**
+ * Initializes the MFRC522 chip.
+ */
+void MFRC522::PCD_Init(	byte resetPowerDownPin	///< Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
+					) {
+	PCD_Init(SS, resetPowerDownPin);
 } // End PCD_Init()
 
 /**

--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -21,7 +21,7 @@ MFRC522::MFRC522() {
  * Prepares the output pins.
  */
 MFRC522::MFRC522(	byte resetPowerDownPin	///< Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
-				): MFRC522(SS, resetPowerDownPin) {
+				): MFRC522(SS, resetPowerDownPin) { // SS is defined in pins_arduino.h
 } // End constructor
 
 /**
@@ -230,7 +230,7 @@ void MFRC522::PCD_Init() {
  */
 void MFRC522::PCD_Init(	byte resetPowerDownPin	///< Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
 					) {
-	PCD_Init(SS, resetPowerDownPin);
+	PCD_Init(SS, resetPowerDownPin); // SS is defined in pins_arduino.h
 } // End PCD_Init()
 
 /**

--- a/MFRC522.h
+++ b/MFRC522.h
@@ -322,6 +322,7 @@ public:
 	// Functions for setting up the Arduino
 	/////////////////////////////////////////////////////////////////////////////////////
 	MFRC522();
+	MFRC522(byte resetPowerDownPin);
 	MFRC522(byte chipSelectPin, byte resetPowerDownPin);
 	
 	/////////////////////////////////////////////////////////////////////////////////////
@@ -340,6 +341,7 @@ public:
 	// Functions for manipulating the MFRC522
 	/////////////////////////////////////////////////////////////////////////////////////
 	void PCD_Init();
+	void PCD_Init(byte resetPowerDownPin);
 	void PCD_Init(byte chipSelectPin, byte resetPowerDownPin);
 	void PCD_Reset();
 	void PCD_AntennaOn();


### PR DESCRIPTION
Get SPI slave select pin automatically by using `SS` defined in `pins_arduino.h`.