### PR TITLE
Add Espressif ESP8266 support in library manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -10,5 +10,5 @@
   "version": "1.1.8",
   "exclude": "doc",
   "frameworks": "arduino",
-  "platforms": ["atmelavr", "ststm32", "teensy"]
+  "platforms": ["atmelavr", "ststm32", "teensy", "espressif"]
 }


### PR DESCRIPTION
Add support for ESP8266 so that it could be installed from platformio lib management system.