### PR TITLE
Selftest completion

### DIFF
--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -331,8 +331,15 @@ bool MFRC522::PCD_PerformSelfTest() {
 	word i;
 	byte n;
 	for (i = 0; i < 0xFF; i++) {
-		n = PCD_ReadRegister(DivIrqReg);	// DivIrqReg[7..0] bits are: Set2 reserved reserved MfinActIRq reserved CRCIRq reserved reserved
-		if (n & 0x04) {						// CRCIRq bit set - calculation done
+		// The datasheet does not specify exact completion condition except
+		// that FIFO buffer should contain 64 bytes.
+		// While selftest is initiated by CalcCRC command
+		// it behaves differently from normal CRC computation,
+		// so one can't reliably use DivIrqReg to check for completion.
+		// It is reported that some devices does not trigger CRCIRq flag
+		// during selftest.
+		n = PCD_ReadRegister(FIFOLevelReg);
+		if (n >= 64) {
 			break;
 		}
 	}


### PR DESCRIPTION
It seems that selftest completion condition
(PCD_ReadRegister(DivIrqReg) & 4) may not work.
On my v1.0 device DivIrqReg is stuck at 0x13 during test,
but output data is generated succesfully.

I think, the better way to check for completion is to
monitor FIFO level register.
