### PR TITLE
Introduce stdint.h

### DIFF
--- a/MFRC522.h
+++ b/MFRC522.h
@@ -369,12 +369,12 @@ public:
 	StatusCode MIFARE_Read(byte blockAddr, byte *buffer, byte *bufferSize);
 	StatusCode MIFARE_Write(byte blockAddr, byte *buffer, byte bufferSize);
 	StatusCode MIFARE_Ultralight_Write(byte page, byte *buffer, byte bufferSize);
-	StatusCode MIFARE_Decrement(byte blockAddr, long delta);
-	StatusCode MIFARE_Increment(byte blockAddr, long delta);
+	StatusCode MIFARE_Decrement(byte blockAddr, int32_t delta);
+	StatusCode MIFARE_Increment(byte blockAddr, int32_t delta);
 	StatusCode MIFARE_Restore(byte blockAddr);
 	StatusCode MIFARE_Transfer(byte blockAddr);
-	StatusCode MIFARE_GetValue(byte blockAddr, long *value);
-	StatusCode MIFARE_SetValue(byte blockAddr, long value);
+	StatusCode MIFARE_GetValue(byte blockAddr, int32_t *value);
+	StatusCode MIFARE_SetValue(byte blockAddr, int32_t value);
 	StatusCode PCD_NTAG216_AUTH(byte *passWord, byte pACK[]);
 	
 	/////////////////////////////////////////////////////////////////////////////////////
@@ -412,7 +412,7 @@ public:
 private:
 	byte _chipSelectPin;		// Arduino pin connected to MFRC522's SPI slave select input (Pin 24, NSS, active low)
 	byte _resetPowerDownPin;	// Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
-	StatusCode MIFARE_TwoStepHelper(byte command, byte blockAddr, long data);
+	StatusCode MIFARE_TwoStepHelper(byte command, byte blockAddr, int32_t data);
 };
 
 #endif

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,13 @@ Support/issue
     Open an issue on github.
 
 
+.. _code style:
+Code style
+----------
+
+Please use ``fixed integers``, see `stdint.h`_. Why? This library is compatible to different boards which use different architectures (16bit vs 32bit). So unfixed ``int`` has different sizes on different environments and may cause unpredictable behaviour.
+
+
 .. _pin layout:
 Pin Layout
 ----------
@@ -269,3 +276,4 @@ It has been extended with functionality to alter sector 0 on Chinese UID changea
 .. _broken: https://eprint.iacr.org/2008/166
 .. _supported by hardware: https://web.archive.org/web/20151210045625/http://www.nxp.com/documents/leaflet/939775017564.pdf
 .. _Arduino forum: https://forum.arduino.cc
+.. _stdint.h: https://en.wikibooks.org/wiki/C_Programming/C_Reference/stdint.h

--- a/examples/MifareClassicValueBlock/MifareClassicValueBlock.ino
+++ b/examples/MifareClassicValueBlock/MifareClassicValueBlock.ino
@@ -98,7 +98,7 @@ void loop() {
     MFRC522::StatusCode status;
     byte buffer[18];
     byte size = sizeof(buffer);
-    long value;
+    int32_t value;
 
     // Authenticate using key A
     Serial.println(F("Authenticating using key A..."));


### PR DESCRIPTION
Makes library better portable for different architectures.
- replace long to int32_t
- fix documentation mu-sign
- add code style to doc
