### PR TITLE
Fix rfid_default_keys.ino

### DIFF
--- a/examples/rfid_default_keys/rfid_default_keys.ino
+++ b/examples/rfid_default_keys/rfid_default_keys.ino
@@ -82,6 +82,11 @@ boolean try_key(MFRC522::MIFARE_Key *key)
     byte block = 0;
     MFRC522::StatusCode status;
     
+    // http://arduino.stackexchange.com/a/14316
+    if ( ! mfrc522.PICC_IsNewCardPresent())
+        return false;
+    if ( ! mfrc522.PICC_ReadCardSerial())
+        return false;
     // Serial.println(F("Authenticating using key A..."));
     status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, block, key, &(mfrc522.uid));
     if (status != MFRC522::STATUS_OK) {


### PR DESCRIPTION
try to change the order of the known keys and meet the bug described at http://arduino.stackexchange.com/a/14316