### PR TITLE
resolved mfrc522.PCD_Init() hang on teensy LC

### DIFF
--- a/src/MFRC522.cpp
+++ b/src/MFRC522.cpp
@@ -179,7 +179,7 @@ void MFRC522::PCD_Init() {
 	if (_resetPowerDownPin != UNUSED_PIN) {
 		// Set the resetPowerDownPin as digital output, do not reset or power down.
 		pinMode(_resetPowerDownPin, OUTPUT);
-	
+		delay(1);
 		if (digitalRead(_resetPowerDownPin) == LOW) {	// The MFRC522 chip is in power down mode.
 			digitalWrite(_resetPowerDownPin, HIGH);		// Exit power down mode. This triggers a hard reset.
 			// Section 8.8.2 in the datasheet says the oscillator start-up time is the start up time of the crystal + 37,74μs. Let us be generous: 50ms.


### PR DESCRIPTION
`mfrc522.PCD_Init()` hangs on Teensy LC. Need a delay between the pinmode change and the read.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | 
