### PR TITLE
GPIO expander support 

### DIFF
--- a/src/MFRC522.h
+++ b/src/MFRC522.h
@@ -312,6 +312,15 @@ public:
 		STATUS_MIFARE_NACK		= 0xff	// A MIFARE PICC responded with NAK.
 	};
 	
+	// Custom chip select callback
+	typedef void (*cs_callback)(void);
+	
+	// A struct containing custom chip select callback
+	typedef struct {
+		cs_callback		cs_select;		// Chip select slave selection
+		cs_callback		cs_unselect;		// Chip select slave release
+	} CS_callback;
+	
 	// A struct used for passing the UID of a PICC.
 	typedef struct {
 		byte		size;			// Number of bytes in the UID. 4, 7 or 10.
@@ -332,7 +341,12 @@ public:
 	/////////////////////////////////////////////////////////////////////////////////////
 	MFRC522(const byte chipSelectPin, const byte resetPowerDownPin,
 			SPIClass *spiClass = &SPI, const SPISettings spiSettings = SPISettings(SPI_CLOCK_DIV4, MSBFIRST, SPI_MODE0))
-			: _chipSelectPin(chipSelectPin), _resetPowerDownPin(resetPowerDownPin),
+			: _chipSelectPin(chipSelectPin),
+			_csCallback(NULL), _resetPowerDownPin(resetPowerDownPin),
+			  _spiClass(spiClass), _spiSettings(spiSettings) {};
+	MFRC522(const CS_callback *csCallback, const byte resetPowerDownPin,
+			SPIClass *spiClass = &SPI, const SPISettings spiSettings = SPISettings(SPI_CLOCK_DIV4, MSBFIRST, SPI_MODE0))
+			: _chipSelectPin(UNUSED_PIN), _csCallback(csCallback),  _resetPowerDownPin(resetPowerDownPin),
 			  _spiClass(spiClass), _spiSettings(spiSettings) {};
 	MFRC522() : MFRC522(UNUSED_PIN, UNUSED_PIN) {};
 	
@@ -352,6 +366,7 @@ public:
 	/////////////////////////////////////////////////////////////////////////////////////
 	void PCD_Init();
 	void PCD_Init(byte chipSelectPin, byte resetPowerDownPin);
+  void PCD_Init(const CS_callback *csCallback, byte resetPowerDownPin);
 	void PCD_Reset();
 	void PCD_AntennaOn();
 	void PCD_AntennaOff();
@@ -422,6 +437,7 @@ public:
 protected:
 	// Pins
 	byte _chipSelectPin;		// Arduino pin connected to MFRC522's SPI slave select input (Pin 24, NSS, active low)
+	const CS_callback * _csCallback;
 	byte _resetPowerDownPin;	// Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
 	
 	// SPI communication
@@ -430,6 +446,8 @@ protected:
 	
 	// Functions for communicating with MIFARE PICCs
 	StatusCode MIFARE_TwoStepHelper(byte command, byte blockAddr, int32_t data);
+	void PCD_csSelect();
+	void PCD_csUnselect();
 };
 
 #endif

--- a/src/MFRC522.h
+++ b/src/MFRC522.h
@@ -321,6 +321,8 @@ public:
 		cs_callback		cs_unselect;		// Chip select slave release
 	} CS_callback;
 	
+	typedef void (*rst_callback)(bool);
+	
 	// A struct used for passing the UID of a PICC.
 	typedef struct {
 		byte		size;			// Number of bytes in the UID. 4, 7 or 10.
@@ -342,11 +344,11 @@ public:
 	MFRC522(const byte chipSelectPin, const byte resetPowerDownPin,
 			SPIClass *spiClass = &SPI, const SPISettings spiSettings = SPISettings(SPI_CLOCK_DIV4, MSBFIRST, SPI_MODE0))
 			: _chipSelectPin(chipSelectPin),
-			_csCallback(NULL), _resetPowerDownPin(resetPowerDownPin),
+			_csCallback(NULL), _rstCallback(NULL), _resetPowerDownPin(resetPowerDownPin),
 			  _spiClass(spiClass), _spiSettings(spiSettings) {};
-	MFRC522(const CS_callback *csCallback, const byte resetPowerDownPin,
+	MFRC522(const CS_callback *csCallback, const rst_callback rstCallback,
 			SPIClass *spiClass = &SPI, const SPISettings spiSettings = SPISettings(SPI_CLOCK_DIV4, MSBFIRST, SPI_MODE0))
-			: _chipSelectPin(UNUSED_PIN), _csCallback(csCallback),  _resetPowerDownPin(resetPowerDownPin),
+			: _chipSelectPin(UNUSED_PIN), _csCallback(csCallback), _rstCallback(rstCallback), _resetPowerDownPin(UNUSED_PIN),
 			  _spiClass(spiClass), _spiSettings(spiSettings) {};
 	MFRC522() : MFRC522(UNUSED_PIN, UNUSED_PIN) {};
 	
@@ -366,8 +368,10 @@ public:
 	/////////////////////////////////////////////////////////////////////////////////////
 	void PCD_Init();
 	void PCD_Init(byte chipSelectPin, byte resetPowerDownPin);
-  void PCD_Init(const CS_callback *csCallback, byte resetPowerDownPin);
+	void PCD_Init(const CS_callback *csCallback, rst_callback rstCallback);
 	void PCD_Reset();
+	void PCD_Poweroff();
+	void PCD_Poweron();
 	void PCD_AntennaOn();
 	void PCD_AntennaOff();
 	byte PCD_GetAntennaGain();
@@ -438,6 +442,7 @@ protected:
 	// Pins
 	byte _chipSelectPin;		// Arduino pin connected to MFRC522's SPI slave select input (Pin 24, NSS, active low)
 	const CS_callback * _csCallback;
+	rst_callback _rstCallback;
 	byte _resetPowerDownPin;	// Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
 	
 	// SPI communication


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

The aims of this pull request is to provide custom callbacks for gpio handling such as chip select and reset. Thanks to that, external gpio expander may be used to control several MFRC522 such as for example an i2c MCP23017.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
