### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,8 +14,8 @@ PICC_Command	KEYWORD1
 MIFARE_Misc	KEYWORD1
 PICC_Type	KEYWORD1
 StatusCode	KEYWORD1
-TagBitRates 	KEYWORD1
-Uid		KEYWORD1
+TagBitRates	KEYWORD1
+Uid	KEYWORD1
 CardInfo	KEYWORD1
 MIFARE_Key	KEYWORD1
 PcbBlock	KEYWORD1
@@ -104,7 +104,7 @@ PICC_ReadCardSerial	KEYWORD2
 #######################################
 
 #######################################
-LITERAL1 Constants
+# LITERAL1 Constants
 #######################################
 CommandReg	LITERAL1
 ComIEnReg	LITERAL1
@@ -163,8 +163,8 @@ PCD_CalcCRC	LITERAL1
 PCD_Transmit	LITERAL1
 PCD_NoCmdChange	LITERAL1
 PCD_Receive	LITERAL1
-PCD_Transceive 	LITERAL1
-PCD_MFAuthent 	LITERAL1
+PCD_Transceive	LITERAL1
+PCD_MFAuthent	LITERAL1
 PCD_SoftReset	LITERAL1
 RxGain_18dB	LITERAL1
 RxGain_23dB	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | NA <!-- #-prefixed issue number(s), if any -->
