### PR TITLE
fix default_keys example for avoid skipping first key

### DIFF
--- a/examples/rfid_default_keys/rfid_default_keys.ino
+++ b/examples/rfid_default_keys/rfid_default_keys.ino
@@ -81,12 +81,7 @@ bool try_key(MFRC522::MIFARE_Key *key)
     byte buffer[18];
     byte block = 0;
     MFRC522::StatusCode status;
-    
-    // http://arduino.stackexchange.com/a/14316
-    if ( ! mfrc522.PICC_IsNewCardPresent())
-        return false;
-    if ( ! mfrc522.PICC_ReadCardSerial())
-        return false;
+
     // Serial.println(F("Authenticating using key A..."));
     status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, block, key, &(mfrc522.uid));
     if (status != MFRC522::STATUS_OK) {
@@ -153,5 +148,11 @@ void loop() {
             // no need to try other keys for this PICC
             break;
         }
+        
+        // http://arduino.stackexchange.com/a/14316
+        if ( ! mfrc522.PICC_IsNewCardPresent())
+            break;
+        if ( ! mfrc522.PICC_ReadCardSerial())
+            break;
     }
 }


### PR DESCRIPTION
mfrc522.PICC_ReadCardSerial() inside try_key returns false on first try_key call because there are no auth after mfrc522.PICC_ReadCardSerial() in the loop beginning.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no 
| Deprecations? | no
