### PR TITLE
Support for Gen2 Chinese card UID change in MIFARE_SetUid

### DIFF
--- a/examples/ChangeUID/ChangeUID.ino
+++ b/examples/ChangeUID/ChangeUID.ino
@@ -91,9 +91,12 @@ void loop() {
 //    return;
 //  }
   
+  //Set to true if card only supports standart commands and not backdoor commands.
+  bool ChineseGEN2_Card = true;
+  
   // Set new UID
   byte newUid[] = NEW_UID;
-  if ( mfrc522.MIFARE_SetUid(newUid, (byte)4, true) ) {
+  if ( mfrc522.MIFARE_SetUid(newUid, (byte)4, ChineseGEN2_Card, true) ) {
     Serial.println(F("Wrote new UID to card."));
   }
   

--- a/src/MFRC522.h
+++ b/src/MFRC522.h
@@ -423,7 +423,7 @@ public:
 	DEPRECATED_MSG("will move to extra class in next version")
 	bool MIFARE_OpenUidBackdoor(bool logErrors);
 	DEPRECATED_MSG("will move to extra class in next version")
-	bool MIFARE_SetUid(byte *newUid, byte uidSize, bool logErrors);
+	bool MIFARE_SetUid(byte *newUid, byte uidSize, bool standartCommands, bool logErrors);
 	DEPRECATED_MSG("will move to extra class in next version")
 	bool MIFARE_UnbrickUidSector(bool logErrors);
 	


### PR DESCRIPTION
Adds standartCommands bool in parameters of MIFARE_SetUid to add support for changing uid on "Gen2 Magic Cards" as these cards doesn't have backdoor commands and only standart commands. But the backward compatibility of this function breaks as new parameter is added.

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as mutch information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | yes <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | none <!-- #-prefixed issue number(s), if any -->
