### PR TITLE
AccessControl.ino: findID omits last entry

### DIFF
--- a/examples/AccessControl/AccessControl.ino
+++ b/examples/AccessControl/AccessControl.ino
@@ -450,7 +450,7 @@ uint8_t findIDSLOT( byte find[] ) {
 ///////////////////////////////////////// Find ID From EEPROM   ///////////////////////////////////
 bool findID( byte find[] ) {
   uint8_t count = EEPROM.read(0);     // Read the first Byte of EEPROM that
-  for ( uint8_t i = 1; i < count; i++ ) {    // Loop once for each EEPROM entry
+  for ( uint8_t i = 1; i <= count; i++ ) {    // Loop once for each EEPROM entry
     readID(i);          // Read an ID from EEPROM, it is stored in storedCard[4]
     if ( checkTwo( find, storedCard ) ) {   // Check to see if the storedCard read from EEPROM
       return true;


### PR DESCRIPTION
I've been playing around with the AccessControl example all day and noticed that sometimes when I tried to delete a known tag it would return "don't know this id" instead and add the tag again, when in fact, it was already written in the eeprom (locally, on my machine, I printed out the entirety of the EEPROM and it was in fact listed).

I noticed that this was only the case on the last added tag and I believe that in the findID() the loop (since it starts at 1) needs to reach count, i.e. i<= count and not i<count (like in findIDSLOT).

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as much information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? |no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
