### PR TITLE
adds megaavr architecture to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino RFID Library for MFRC522 (SPI)
 paragraph=Read/Write a RFID Card or Tag using the ISO/IEC 14443A/MIFARE interface.
 category=Communication
 url=https://github.com/miguelbalboa/rfid
-architectures=avr,STM32F1,teensy,esp8266,esp32,samd
+architectures=avr,megaavr,STM32F1,teensy,esp8266,esp32,samd


### PR DESCRIPTION
Removes the following warning when compiling on the new Arduino Nano Every:

> WARNING: library MFRC522 claims to run on (avr, STM32F1, teensy, esp8266, samd) architecture(s) and may be incompatible with your current board which runs on (megaavr) architecture(s).

| Q             | A
| ------------- | ---
| Bug fix?      | well kind of, fixes just above warning
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #483