### PR TITLE
Fix detection of ISO/IEC 14443 and ISO/IEC 18092 cards

### DIFF
--- a/src/MFRC522.cpp
+++ b/src/MFRC522.cpp
@@ -1304,8 +1304,13 @@ MFRC522::PICC_Type MFRC522::PICC_GetType(byte sak		///< The SAK byte returned fr
 	// ignore 8-bit (iso14443 starts with LSBit = bit 1)
 	// fixes wrong type for manufacturer Infineon (http://nfc-tools.org/index.php?title=ISO14443A)
 	sak &= 0x7F;
+	if (sak & 0x04)
+		return PICC_TYPE_NOT_COMPLETE;	// UID not complete
+	if (sak & 0x20)
+		return PICC_TYPE_ISO_14443_4;
+	if (sak & 0x40)
+		return PICC_TYPE_ISO_18092;
 	switch (sak) {
-		case 0x04:	return PICC_TYPE_NOT_COMPLETE;	// UID not complete
 		case 0x09:	return PICC_TYPE_MIFARE_MINI;
 		case 0x08:	return PICC_TYPE_MIFARE_1K;
 		case 0x18:	return PICC_TYPE_MIFARE_4K;
@@ -1313,8 +1318,6 @@ MFRC522::PICC_Type MFRC522::PICC_GetType(byte sak		///< The SAK byte returned fr
 		case 0x10:
 		case 0x11:	return PICC_TYPE_MIFARE_PLUS;
 		case 0x01:	return PICC_TYPE_TNP3XXX;
-		case 0x20:	return PICC_TYPE_ISO_14443_4;
-		case 0x40:	return PICC_TYPE_ISO_18092;
 		default:	return PICC_TYPE_UNKNOWN;
 	}
 } // End PICC_GetType()

--- a/src/MFRC522.cpp
+++ b/src/MFRC522.cpp
@@ -1303,9 +1303,36 @@ MFRC522::PICC_Type MFRC522::PICC_GetType(byte sak		///< The SAK byte returned fr
 	// 3.2 Coding of Select Acknowledge (SAK)
 	// ignore 8-bit (iso14443 starts with LSBit = bit 1)
 	// fixes wrong type for manufacturer Infineon (http://nfc-tools.org/index.php?title=ISO14443A)
+	//
+	// ISO/IEC 14443-3:2016 chapter 6.5.3.4 describes coding of SAK:
+	//
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+	// | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 |              Meaning             |
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+	// | x | x | x | x | x | 1 | x | x | UID not complete                 |
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+	// | x | x | 1 | x | x | 0 | x | x | UID complete, PICC compliant     |
+	// |   |   |   |   |   |   |   |   | with ISO/IEC 14443-4             |
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+	// | x | x | 0 | x | x | 0 | x | x | UID complete, PICC not compliant |
+	// |   |   |   |   |   |   |   |   | with ISO/IEC 14443-4             |
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+	//
+	// ISO/IEC 18092:2013 chapter 11.2.1 adds the following:
+	//
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+	// | 8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 |              Meaning             |
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+	// | x | 1 | x | x | x | 0 | x | x | UID complete, PICC compliant     |
+	// |   |   |   |   |   |   |   |   | with NFCIP-1 transport protocol  |
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+	// | x | 0 | x | x | x | 0 | x | x | UID complete, PICC not compliant |
+	// |   |   |   |   |   |   |   |   | with NFCIP-1 transport protocol  |
+	// +---+---+---+---+---+---+---+---+----------------------------------+
+
 	sak &= 0x7F;
 	if (sak & 0x04)
-		return PICC_TYPE_NOT_COMPLETE;	// UID not complete
+		return PICC_TYPE_NOT_COMPLETE;
 	if (sak & 0x20)
 		return PICC_TYPE_ISO_14443_4;
 	if (sak & 0x40)

--- a/src/MFRC522Extended.cpp
+++ b/src/MFRC522Extended.cpp
@@ -957,27 +957,12 @@ MFRC522::StatusCode MFRC522Extended::TCL_Deselect(TagInfo *tag)
  */
 MFRC522::PICC_Type MFRC522Extended::PICC_GetType(TagInfo *tag		///< The TagInfo returned from PICC_Select().
 ) {
-	// http://www.nxp.com/documents/application_note/AN10833.pdf 
-	// 3.2 Coding of Select Acknowledge (SAK)
-	// ignore 8-bit (iso14443 starts with LSBit = bit 1)
-	// fixes wrong type for manufacturer Infineon (http://nfc-tools.org/index.php?title=ISO14443A)
-	byte sak = tag->uid.sak & 0x7F;
-	switch (sak) {
-		case 0x04:	return PICC_TYPE_NOT_COMPLETE;	// UID not complete
-		case 0x09:	return PICC_TYPE_MIFARE_MINI;
-		case 0x08:	return PICC_TYPE_MIFARE_1K;
-		case 0x18:	return PICC_TYPE_MIFARE_4K;
-		case 0x00:	return PICC_TYPE_MIFARE_UL;
-		case 0x10:
-		case 0x11:	return PICC_TYPE_MIFARE_PLUS;
-		case 0x01:	return PICC_TYPE_TNP3XXX;
-		case 0x20:
-			if (tag->atqa == 0x0344)
-				return PICC_TYPE_MIFARE_DESFIRE;
-			return PICC_TYPE_ISO_14443_4;
-		case 0x40:	return PICC_TYPE_ISO_18092;
-		default:	return PICC_TYPE_UNKNOWN;
-	}
+	MFRC522::PICC_Type result = PICC_GetType(tag->uid.sak);
+
+	if (result == PICC_TYPE_ISO_14443_4 && tag->atqa == 0x0344)
+		result = PICC_TYPE_MIFARE_DESFIRE;
+
+	return result;
 } // End PICC_GetType()
 
 /**


### PR DESCRIPTION
Information about SAK coding in both ISO/IEC 14443-3 and ISO/IEC 18092 shows that most of the bits are "don't care", so the value should not be compared as whole but bitmasked instead:

| bit 8 | bit 7 | bit 6 | bit 5 | bit 4 | bit 3 | bit 2 | bit 1 | Meaning
| ----- | ----- | ----- | ----- | ----- | ----- | ----- | -----  | ------------------------------------------------------------
|   x   |   x   |   x   |   x   |   x   |   1   |   x   |   x   | UID not complete
|   x   |   x   |   1   |   x   |   x   |   0   |   x   |   x   | UID complete, compliant with ISO/IEC 14443-4
|   x   |   x   |   0   |   x   |   x   |   0   |   x   |   x   | UID complete, not compliant ISO/IEC 14443-4
|   x   |   1   |   x   |   x   |   x   |   0   |   x   |   x   | UID complete, compliant with ISO/IEC 18092
|   x   |   0   |   x   |   x   |   x   |   0   |   x   |   x   | UID complete, not compliant ISO/IEC 18092

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no 
| Deprecations? | no
| Fixed tickets | N/A 
