### PR TITLE
Add architecture mbed, Fix MFRC522_SPICLOCK error to Arduino Nano33BLE

### DIFF
--- a/library.json
+++ b/library.json
@@ -10,5 +10,5 @@
   "version": "1.4.5",
   "exclude": "doc",
   "frameworks": "arduino",
-  "platforms": ["atmelavr", "ststm32", "espressif8266","espressif32","samd"]
+  "platforms": ["atmelavr", "ststm32", "espressif8266","espressif32","samd","mbed"]
 }

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino RFID Library for MFRC522 (SPI)
 paragraph=Read/Write a RFID Card or Tag using the ISO/IEC 14443A/MIFARE interface.
 category=Communication
 url=https://github.com/miguelbalboa/rfid
-architectures=avr,megaavr,STM32F1,teensy,esp8266,esp32,samd
+architectures=avr,megaavr,STM32F1,teensy,esp8266,esp32,samd,mbed

--- a/src/MFRC522.h
+++ b/src/MFRC522.h
@@ -84,7 +84,11 @@
 #include <SPI.h>
 
 #ifndef MFRC522_SPICLOCK
+#ifdef ARDUINO_ARDUINO_NANO33BLE
+#define MFRC522_SPICLOCK 0
+#else
 #define MFRC522_SPICLOCK SPI_CLOCK_DIV4			// MFRC522 accept upto 10MHz
+#endif
 #endif
 
 // Firmware data for self-test


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as much information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

Remove compile warning on Arduino Nano33BLE.
mbed architecture SPI.h not defined SPI_CLOCK_DIV, so add MFRC522_SPICLOCK define.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
