### PR TITLE
Allow use of any pins by implementing Soft SPI

### DIFF
--- a/examples/DumpInfo_SoftSPI/DumpInfo_SoftSPI.ino
+++ b/examples/DumpInfo_SoftSPI/DumpInfo_SoftSPI.ino
@@ -1,0 +1,75 @@
+/*
+ * --------------------------------------------------------------------------------------------------------------------
+ * Example sketch/program showing how to read data from a PICC to serial.
+ * --------------------------------------------------------------------------------------------------------------------
+ * This is a MFRC522 library example; for further details and other examples see: https://github.com/miguelbalboa/rfid
+ * 
+ * Example sketch/program showing how to read data from a PICC (that is: a RFID Tag or Card) using a MFRC522 based RFID
+ * Reader on the Arduino SPI interface.
+ *
+ * NOTE: This example use emulated SPI in software, aallowing you to use any pins for MISO, MOSI, SCK. 
+ * 
+ * When the Arduino and the MFRC522 module are connected (see the pin layout below), load this sketch into Arduino IDE
+ * then verify/compile and upload it. To see the output: use Tools, Serial Monitor of the IDE (hit Ctrl+Shft+M). When
+ * you present a PICC (that is: a RFID Tag or Card) at reading distance of the MFRC522 Reader/PCD, the serial output
+ * will show the ID/UID, type and any data blocks it can read. Note: you may see "Timeout in communication" messages
+ * when removing the PICC from reading distance too early.
+ * 
+ * If your reader supports it, this sketch/program will read all the PICCs presented (that is: multiple tag reading).
+ * So if you stack two or more PICCs on top of each other and present them to the reader, it will first output all
+ * details of the first and then the next PICC. Note that this may take some time as all data blocks are dumped, so
+ * keep the PICCs at reading distance until complete.
+ * 
+ * @license Released into the public domain.
+ * 
+ * Typical pin layout used:
+ * -----------------------------------------------------------------------------------------
+ *             MFRC522      Arduino       Arduino   Arduino    Arduino          Arduino
+ *             Reader/PCD   Uno/101       Mega      Nano v3    Leonardo/Micro   Pro Micro
+ * Signal      Pin          Pin           Pin       Pin        Pin              Pin
+ * -----------------------------------------------------------------------------------------
+ * RST/Reset   RST          9             5         D9         RESET/ICSP-5     RST
+ * SPI SS      SDA(SS)      10            53        D10        10               10
+ * SPI MOSI    MOSI         11 / ICSP-4   51        D11        ICSP-4           16
+ * SPI MISO    MISO         12 / ICSP-1   50        D12        ICSP-1           14
+ * SPI SCK     SCK          13 / ICSP-3   52        D13        ICSP-3           15
+ */
+
+
+// Best Pins for: ARDUINO NANO
+#define RFID_SS 15 // A1
+#define RFID_SCK 16 // A2
+#define RFID_MOSI 17// A3
+#define RFID_MISO 18 // A4
+#define RFID_RST 21 // A7  
+ 
+
+#include <MFRC522.h>
+#include <utility/SoftSPI.h> // Included in MFRC522 lib
+
+MFRC522 mfrc522(RFID_SS, RFID_RST);  // Create MFRC522 instance
+
+void setup() {
+	Serial.begin(115200);		// Initialize serial communications with the PC
+	while (!Serial);		// Do nothing if no serial port is opened (added for Arduinos based on ATMEGA32U4)
+	S_SPI.begin(RFID_SCK, RFID_MOSI, RFID_MISO);	// Init SoftSPI with alternate pins
+	mfrc522.PCD_Init();		// Init MFRC522
+	delay(4);				// Optional delay. Some board do need more time after init to be ready, see Readme
+	mfrc522.PCD_DumpVersionToSerial();	// Show details of PCD - MFRC522 Card Reader details
+	Serial.println(F("Scan PICC to see UID, SAK, type, and data blocks..."));
+}
+
+void loop() {
+	// Reset the loop if no new card present on the sensor/reader. This saves the entire process when idle.
+	if ( ! mfrc522.PICC_IsNewCardPresent()) {
+		return;
+	}
+
+	// Select one of the cards
+	if ( ! mfrc522.PICC_ReadCardSerial()) {
+		return;
+	}
+
+	// Dump debug info about the card; PICC_HaltA() is automatically called
+	mfrc522.PICC_DumpToSerial(&(mfrc522.uid));
+}

--- a/src/MFRC522.cpp
+++ b/src/MFRC522.cpp
@@ -46,12 +46,12 @@ MFRC522::MFRC522(	byte chipSelectPin,		///< Arduino pin connected to MFRC522's S
 void MFRC522::PCD_WriteRegister(	PCD_Register reg,	///< The register to write to. One of the PCD_Register enums.
 									byte value			///< The value to write.
 								) {
-	SPI.beginTransaction(SPISettings(MFRC522_SPICLOCK, MSBFIRST, SPI_MODE0));	// Set the settings to work with SPI bus
+	MFRC522_SPI.beginTransaction(SPISettings(MFRC522_SPICLOCK, MSBFIRST, SPI_MODE0));	// Set the settings to work with SPI bus
 	digitalWrite(_chipSelectPin, LOW);		// Select slave
-	SPI.transfer(reg);						// MSB == 0 is for writing. LSB is not used in address. Datasheet section 8.1.2.3.
-	SPI.transfer(value);
+	MFRC522_SPI.transfer(reg);						// MSB == 0 is for writing. LSB is not used in address. Datasheet section 8.1.2.3.
+	MFRC522_SPI.transfer(value);
 	digitalWrite(_chipSelectPin, HIGH);		// Release slave again
-	SPI.endTransaction(); // Stop using the SPI bus
+	MFRC522_SPI.endTransaction(); // Stop using the SPI bus
 } // End PCD_WriteRegister()
 
 /**
@@ -62,14 +62,14 @@ void MFRC522::PCD_WriteRegister(	PCD_Register reg,	///< The register to write to
 									byte count,			///< The number of bytes to write to the register
 									byte *values		///< The values to write. Byte array.
 								) {
-	SPI.beginTransaction(SPISettings(MFRC522_SPICLOCK, MSBFIRST, SPI_MODE0));	// Set the settings to work with SPI bus
+	MFRC522_SPI.beginTransaction(SPISettings(MFRC522_SPICLOCK, MSBFIRST, SPI_MODE0));	// Set the settings to work with SPI bus
 	digitalWrite(_chipSelectPin, LOW);		// Select slave
-	SPI.transfer(reg);						// MSB == 0 is for writing. LSB is not used in address. Datasheet section 8.1.2.3.
+	MFRC522_SPI.transfer(reg);						// MSB == 0 is for writing. LSB is not used in address. Datasheet section 8.1.2.3.
 	for (byte index = 0; index < count; index++) {
-		SPI.transfer(values[index]);
+		MFRC522_SPI.transfer(values[index]);
 	}
 	digitalWrite(_chipSelectPin, HIGH);		// Release slave again
-	SPI.endTransaction(); // Stop using the SPI bus
+	MFRC522_SPI.endTransaction(); // Stop using the SPI bus
 } // End PCD_WriteRegister()
 
 /**
@@ -79,12 +79,12 @@ void MFRC522::PCD_WriteRegister(	PCD_Register reg,	///< The register to write to
 byte MFRC522::PCD_ReadRegister(	PCD_Register reg	///< The register to read from. One of the PCD_Register enums.
 								) {
 	byte value;
-	SPI.beginTransaction(SPISettings(MFRC522_SPICLOCK, MSBFIRST, SPI_MODE0));	// Set the settings to work with SPI bus
+	MFRC522_SPI.beginTransaction(SPISettings(MFRC522_SPICLOCK, MSBFIRST, SPI_MODE0));	// Set the settings to work with SPI bus
 	digitalWrite(_chipSelectPin, LOW);			// Select slave
-	SPI.transfer(0x80 | reg);					// MSB == 1 is for reading. LSB is not used in address. Datasheet section 8.1.2.3.
-	value = SPI.transfer(0);					// Read the value back. Send 0 to stop reading.
+	MFRC522_SPI.transfer(0x80 | reg);					// MSB == 1 is for reading. LSB is not used in address. Datasheet section 8.1.2.3.
+	value = MFRC522_SPI.transfer(0);					// Read the value back. Send 0 to stop reading.
 	digitalWrite(_chipSelectPin, HIGH);			// Release slave again
-	SPI.endTransaction(); // Stop using the SPI bus
+	MFRC522_SPI.endTransaction(); // Stop using the SPI bus
 	return value;
 } // End PCD_ReadRegister()
 
@@ -103,26 +103,26 @@ void MFRC522::PCD_ReadRegister(	PCD_Register reg,	///< The register to read from
 	//Serial.print(F("Reading ")); 	Serial.print(count); Serial.println(F(" bytes from register."));
 	byte address = 0x80 | reg;				// MSB == 1 is for reading. LSB is not used in address. Datasheet section 8.1.2.3.
 	byte index = 0;							// Index in values array.
-	SPI.beginTransaction(SPISettings(MFRC522_SPICLOCK, MSBFIRST, SPI_MODE0));	// Set the settings to work with SPI bus
+	MFRC522_SPI.beginTransaction(SPISettings(MFRC522_SPICLOCK, MSBFIRST, SPI_MODE0));	// Set the settings to work with SPI bus
 	digitalWrite(_chipSelectPin, LOW);		// Select slave
 	count--;								// One read is performed outside of the loop
-	SPI.transfer(address);					// Tell MFRC522 which address we want to read
+	MFRC522_SPI.transfer(address);					// Tell MFRC522 which address we want to read
 	if (rxAlign) {		// Only update bit positions rxAlign..7 in values[0]
 		// Create bit mask for bit positions rxAlign..7
 		byte mask = (0xFF << rxAlign) & 0xFF;
 		// Read value and tell that we want to read the same address again.
-		byte value = SPI.transfer(address);
+		byte value = MFRC522_SPI.transfer(address);
 		// Apply mask to both current value of values[0] and the new data in value.
 		values[0] = (values[0] & ~mask) | (value & mask);
 		index++;
 	}
 	while (index < count) {
-		values[index] = SPI.transfer(address);	// Read value and tell that we want to read the same address again.
+		values[index] = MFRC522_SPI.transfer(address);	// Read value and tell that we want to read the same address again.
 		index++;
 	}
-	values[index] = SPI.transfer(0);			// Read the final byte. Send 0 to stop reading.
+	values[index] = MFRC522_SPI.transfer(0);			// Read the final byte. Send 0 to stop reading.
 	digitalWrite(_chipSelectPin, HIGH);			// Release slave again
-	SPI.endTransaction(); // Stop using the SPI bus
+	MFRC522_SPI.endTransaction(); // Stop using the SPI bus
 } // End PCD_ReadRegister()
 
 /**

--- a/src/MFRC522.h
+++ b/src/MFRC522.h
@@ -87,6 +87,16 @@
 #define MFRC522_SPICLOCK SPI_CLOCK_DIV4			// MFRC522 accept upto 10MHz
 #endif
 
+// uncommento to enable use of "any" pins as SPI (SCK, MOSI, MISO)
+// #define MFRC522_SOFTSPI 1
+
+#if MFRC522_SOFTSPI
+#include "utility/SoftSPI.h"
+#define MFRC522_SPI S_SPI   // SoftSPI
+#else
+#define MFRC522_SPI SPI     // Native SPI   
+#endif
+
 // Firmware data for self-test
 // Reference values based on firmware version
 // Hint: if needed, you can remove unused self-test data to save flash memory

--- a/src/utility/SoftSPI.cpp
+++ b/src/utility/SoftSPI.cpp
@@ -1,0 +1,80 @@
+
+#include "Arduino.h"
+#include "SoftSPI.h"
+
+
+SoftSPI S_SPI;
+
+uint8_t SoftSPI::_sckPin = 0;
+uint8_t SoftSPI::_mosiPin = 0;
+uint8_t SoftSPI::_misoPin = 0;
+
+SoftSPI::SoftSPI() {
+  
+}
+
+void SoftSPI::begin(uint8_t sck, uint8_t mosi, uint8_t miso)
+{
+  _sckPin = sck;
+  _mosiPin = mosi;
+  _misoPin = miso;
+  pinMode(_sckPin, OUTPUT);
+  pinMode(_mosiPin, OUTPUT);
+  pinMode(_misoPin, INPUT);
+
+}
+
+void SoftSPI::end()
+{
+  pinMode(_sckPin, INPUT);
+  pinMode(_mosiPin, INPUT);
+  pinMode(_misoPin, INPUT);
+}
+
+
+uint8_t SoftSPI::readByte(void)
+{
+  uint8_t n,dat,bit_t;
+  for(n = 0; n < 8; n ++)
+  {
+    digitalWrite(_sckPin, LOW);
+	dat <<= 1;
+	if(digitalRead(_misoPin))
+	{
+	  dat |= 0x01;
+	}
+	else
+	{
+	  dat &= 0xfe;
+	}
+	digitalWrite(_sckPin, HIGH);
+  }
+  digitalWrite(_sckPin, LOW);
+  return dat;
+}
+
+uint8_t SoftSPI::transfer(uint8_t data)
+{
+  uint8_t i;
+
+  for(i=0;i<8;i++)                      // output 8-bit
+  {
+    if(data&0x80)
+    {
+      digitalWrite(_mosiPin, 1);
+    }
+    else
+    {
+      digitalWrite(_mosiPin, 0);
+    }
+    digitalWrite(_sckPin, 1);
+    data <<= 1;                         // shift next bit into MSB..
+    if(digitalRead(_misoPin) == 1)
+    {
+      data |= 1;                         // capture current MISO bit
+    }
+    digitalWrite(_sckPin, 0);
+  }
+  return(data);                    // return read unsigned char
+}
+

--- a/src/utility/SoftSPI.h
+++ b/src/utility/SoftSPI.h
@@ -1,0 +1,25 @@
+#ifndef __SOFTSPI_H
+#define __SOFTSPI_H
+
+#include <SPI.h>
+
+class SoftSPI
+{
+  public:
+    SoftSPI();
+	static void begin(uint8_t mosi, uint8_t miso, uint8_t sck);
+    inline static void beginTransaction(SPISettings settings){}; // do nothing (may be disable iterrupts ?)
+    inline static void endTransaction(void) {}; // do nothing (may be enable iterrupts ?)
+    static void end();
+	static uint8_t transfer(uint8_t dat);
+	static uint8_t readByte(void);
+
+  private:
+	static uint8_t _sckPin;
+	static uint8_t _mosiPin;
+	static uint8_t _misoPin;
+};
+
+extern SoftSPI S_SPI;
+
+#endif


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | yes
| BC    | yes <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This change allows the use of any pin by implementing communication via software.

Due to the poor design of the SPI class, the only way I could do this integration was by creating a new define (MFRC522_SOFTSPI), which needs to be enabled in the file: MFRC522.h

I added a new example that demonstrates the use: DumpInfo_SoftSPI

## Tests:
| Q             | A
| ------------- | ---
| DumpInfo      | yes
| rfid_write_personal_data  | yes
| rfid_read_personal_data  | yes 

This enables direct stacking of NANO and PRO MICRO arduinos, as in the example:

![Seleção_047](https://user-images.githubusercontent.com/515675/72197936-c7d00100-3405-11ea-8d64-c3ca6904d4c9.jpg)
