### PR TITLE
adding HSPI support for ESP32

### DIFF
--- a/src/MFRC522.h
+++ b/src/MFRC522.h
@@ -337,6 +337,7 @@ public:
 	MFRC522();
 	MFRC522(byte resetPowerDownPin);
 	MFRC522(byte chipSelectPin, byte resetPowerDownPin);
+	MFRC522(  byte chipSelectPin, byte resetPowerDownPin, SPIClass *_spiRFID );
 	
 	/////////////////////////////////////////////////////////////////////////////////////
 	// Basic interface functions for communicating with the MFRC522
@@ -431,6 +432,7 @@ protected:
 	byte _chipSelectPin;		// Arduino pin connected to MFRC522's SPI slave select input (Pin 24, NSS, active low)
 	byte _resetPowerDownPin;	// Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
 	StatusCode MIFARE_TwoStepHelper(byte command, byte blockAddr, int32_t data);
+	SPIClass * spiRFID; //using an pointer to the SPI port, usefull for ESP32
 };
 
 #endif


### PR DESCRIPTION
Using a pointer to the SPI class and a constructor that set the SPI class. (according with MFRC522.cpp)

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as much information as you can.
Not used rows can be deleted.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| Doc update?   | yes/no
| BC breaks?    | yes/no <!-- BC = backwards compatibility -->
| Deprecations? | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
