### PR TITLE
Fix last written tag not being checked

### DIFF
--- a/examples/AccessControl/AccessControl.ino
+++ b/examples/AccessControl/AccessControl.ino
@@ -450,7 +450,7 @@ uint8_t findIDSLOT( byte find[] ) {
 ///////////////////////////////////////// Find ID From EEPROM   ///////////////////////////////////
 bool findID( byte find[] ) {
   uint8_t count = EEPROM.read(0);     // Read the first Byte of EEPROM that
-  for ( uint8_t i = 1; i < count; i++ ) {    // Loop once for each EEPROM entry
+  for ( uint8_t i = 1; i <= count; i++ ) {    // Loop once for each EEPROM entry
     readID(i);          // Read an ID from EEPROM, it is stored in storedCard[4]
     if ( checkTwo( find, storedCard ) ) {   // Check to see if the storedCard read from EEPROM
       return true;


### PR DESCRIPTION
The last rfid tag written was not properly detected as authorized, typical off by one error.