### PR TITLE
fix: timeout on Non-AVR boards; feat: Use yield() in busy wait loops

### DIFF
--- a/src/MFRC522.cpp
+++ b/src/MFRC522.cpp
@@ -167,7 +167,7 @@ MFRC522::StatusCode MFRC522::PCD_CalculateCRC(	byte *data,		///< In: Pointer to 
 	// indicate that the CRC calculation is complete in a loop. If the
 	// calculation is not indicated as complete in ~90ms, then time out
 	// the operation.
-	uint32_t deadline = millis() + 89;
+	const uint32_t deadline = millis() + 89;
 
 	do {
 		// DivIrqReg[7..0] bits are: Set2 reserved reserved MfinActIRq reserved CRCIRq reserved reserved
@@ -491,7 +491,7 @@ MFRC522::StatusCode MFRC522::PCD_CommunicateWithPICC(	byte command,		///< The co
 	// When they are set in the ComIrqReg register, then the command is
 	// considered complete. If the command is not indicated as complete in
 	// ~36ms, then consider the command as timed out.
-	uint32_t deadline = millis() + 36;
+	const uint32_t deadline = millis() + 36;
 	bool completed = false;
 
 	do {
@@ -507,7 +507,7 @@ MFRC522::StatusCode MFRC522::PCD_CommunicateWithPICC(	byte command,		///< The co
 	}
 	while (static_cast<uint32_t> (millis()) < deadline);
 
-	// 36ms and nothing happend. Communication with the MFRC522 might be down.
+	// 36ms and nothing happened. Communication with the MFRC522 might be down.
 	if (!completed) {
 		return STATUS_TIMEOUT;
 	}


### PR DESCRIPTION
Also, be more scientific about the timeouts rather than using a set number of loops, the time of which depends on the value of the `MRFC522_SPICLOCK` as well as `F_CPU`. Instead, use a set number of milliseconds as a deadline.

In my project, I'm using the EventResponder to perform activities during busy wait loops like some of the loops in the library. Using `yield()` allows the timing on the activities to be more consistent. Plus, I'm also putting the MCU into a lower power mode in as part of the EventResponder/idle loop which allows for better power and heat management in `delay` and wait loops.

On the Teensy platform, a call to `millis()` is free as it's a register lookup. It's also a register lookup on the Arduino platform with a very small amount of overhead. All in all, for folks not using `yield()` I would think this edit wouldn't provide a negative impact.

edit by @Rotzbua : The previous timeout code was designed for AVR based Arduinos. Now it should work properly on Non-AVR boards. So I think it is also a bug fix.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | not sure <!-- #-prefixed issue number(s), if any -->
