### PR TITLE
add support for 7 byte Ultralight NUID in ReadNUID

### DIFF
--- a/examples/ReadNUID/ReadNUID.ino
+++ b/examples/ReadNUID/ReadNUID.ino
@@ -41,7 +41,7 @@ MFRC522 rfid(SS_PIN, RST_PIN); // Instance of the class
 MFRC522::MIFARE_Key key; 
 
 // Init array that will store new NUID 
-byte nuidPICC[4];
+byte nuidPICC[7];
 
 void setup() { 
   Serial.begin(9600);
@@ -74,20 +74,20 @@ void loop() {
   // Check is the PICC of Classic MIFARE type
   if (piccType != MFRC522::PICC_TYPE_MIFARE_MINI &&  
     piccType != MFRC522::PICC_TYPE_MIFARE_1K &&
-    piccType != MFRC522::PICC_TYPE_MIFARE_4K) {
-    Serial.println(F("Your tag is not of type MIFARE Classic."));
+    piccType != MFRC522::PICC_TYPE_MIFARE_4K &&
+    piccType != MFRC522::PICC_TYPE_MIFARE_UL) {
+    Serial.println(F("Your tag is not of type MIFARE Classic or MIFARE Ultralight."));
     return;
   }
 
-  if (rfid.uid.uidByte[0] != nuidPICC[0] || 
-    rfid.uid.uidByte[1] != nuidPICC[1] || 
-    rfid.uid.uidByte[2] != nuidPICC[2] || 
-    rfid.uid.uidByte[3] != nuidPICC[3] ) {
+  if(areUIDsIdentical(rfid.uid.uidByte, nuidPICC, sizeof(nuidPICC)/sizeof(nuidPICC[0]))) {
+    Serial.println(F("Card read previously."));
+  } else {
     Serial.println(F("A new card has been detected."));
 
     // Store NUID into nuidPICC array
-    for (byte i = 0; i < 4; i++) {
-      nuidPICC[i] = rfid.uid.uidByte[i];
+    for (byte i = 0; i < 7; i++) {
+      nuidPICC[i] = i >= rfid.uid.size ? 0x00 : rfid.uid.uidByte[i];
     }
    
     Serial.println(F("The NUID tag is:"));
@@ -98,7 +98,6 @@ void loop() {
     printDec(rfid.uid.uidByte, rfid.uid.size);
     Serial.println();
   }
-  else Serial.println(F("Card read previously."));
 
   // Halt PICC
   rfid.PICC_HaltA();
@@ -107,6 +106,15 @@ void loop() {
   rfid.PCD_StopCrypto1();
 }
 
+/**
+ * Helper routine to check if the given UID's are identical
+ */
+bool areUIDsIdentical(byte *uid1, byte *uid2, byte uidLength) {
+  for (byte i = 0; i < uidLength; i++) {
+    if(uid1[i] != uid2[i]) return false;
+  }
+  return true;
+}
 
 /**
  * Helper routine to dump a byte array as hex values to Serial. 


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as much information as you can.
Not used rows can be deleted.

Please create just PRs wiht fixes/typos or documentation updates; no extensions for other boards; no new examples. See development status.

END - This is a comment just for you visible -->

The library supports reading NUID of Ultralight tags but ReadNUID example didn't display them. This can be confusing for newcomers and it may suggest that newer Ultralight tags are completely unsupported or there is a problem with the RFID module. I have corrected ReadNUID example.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | no <!-- #-prefixed issue number(s), if any -->
