### PR TITLE
Removed unused variable key from examples

### DIFF
--- a/examples/ChangeUID/ChangeUID.ino
+++ b/examples/ChangeUID/ChangeUID.ino
@@ -35,19 +35,12 @@ MFRC522 mfrc522(SS_PIN, RST_PIN);   // Create MFRC522 instance
 /* Set your new UID here! */
 #define NEW_UID {0xDE, 0xAD, 0xBE, 0xEF}
 
-MFRC522::MIFARE_Key key;
-
 void setup() {
   Serial.begin(9600);  // Initialize serial communications with the PC
   while (!Serial);     // Do nothing if no serial port is opened (added for Arduinos based on ATMEGA32U4)
   SPI.begin();         // Init SPI bus
   mfrc522.PCD_Init();  // Init MFRC522 card
   Serial.println(F("Warning: this example overwrites the UID of your UID changeable card, use with care!"));
-  
-  // Prepare key - all keys are set to FFFFFFFFFFFFh at chip delivery from the factory.
-  for (byte i = 0; i < 6; i++) {
-    key.keyByte[i] = 0xFF;
-  }
 }
 
 // Setting the UID can be as simple as this:

--- a/examples/FixBrickedUID/FixBrickedUID.ino
+++ b/examples/FixBrickedUID/FixBrickedUID.ino
@@ -32,19 +32,12 @@
 
 MFRC522 mfrc522(SS_PIN, RST_PIN);   // Create MFRC522 instance
 
-MFRC522::MIFARE_Key key;
-
 void setup() {
   Serial.begin(9600);  // Initialize serial communications with the PC
   while (!Serial);     // Do nothing if no serial port is opened (added for Arduinos based on ATMEGA32U4)
   SPI.begin();         // Init SPI bus
   mfrc522.PCD_Init();  // Init MFRC522 card
   Serial.println(F("Warning: this example clears your mifare UID, use with care!"));
-  
-  // Prepare key - all keys are set to FFFFFFFFFFFFh at chip delivery from the factory.
-  for (byte i = 0; i < 6; i++) {
-    key.keyByte[i] = 0xFF;
-  }
 }
 
 void loop() {

--- a/examples/MinimalInterrupt/MinimalInterrupt.ino
+++ b/examples/MinimalInterrupt/MinimalInterrupt.ino
@@ -37,8 +37,6 @@
 
 MFRC522 mfrc522(SS_PIN, RST_PIN);   // Create MFRC522 instance.
 
-MFRC522::MIFARE_Key key;
-
 volatile bool bNewInt = false;
 byte regVal = 0x7F;
 void activateRec(MFRC522 mfrc522);

--- a/examples/ReadNUID/ReadNUID.ino
+++ b/examples/ReadNUID/ReadNUID.ino
@@ -38,8 +38,6 @@
  
 MFRC522 rfid(SS_PIN, RST_PIN); // Instance of the class
 
-MFRC522::MIFARE_Key key; 
-
 // Init array that will store new NUID 
 byte nuidPICC[4];
 
@@ -48,13 +46,7 @@ void setup() {
   SPI.begin(); // Init SPI bus
   rfid.PCD_Init(); // Init MFRC522 
 
-  for (byte i = 0; i < 6; i++) {
-    key.keyByte[i] = 0xFF;
-  }
-
   Serial.println(F("This code scan the MIFARE Classsic NUID."));
-  Serial.print(F("Using the following key:"));
-  printHex(key.keyByte, MFRC522::MF_KEY_SIZE);
 }
  
 void loop() {


### PR DESCRIPTION
<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as much information as you can.
Not used rows can be deleted.

Please create just PRs wiht fixes/typos or documentation updates; no extensions for other boards; no new examples. See development status.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no

Removed the unused variable key in some examples, which can be misleading.