### PR TITLE
Add rp2040 as compatible platform

### DIFF
--- a/library.json
+++ b/library.json
@@ -11,5 +11,5 @@
   },
   "exclude": "doc",
   "frameworks": "arduino",
-  "platforms": ["atmelavr", "atmelsam", "ststm32", "espressif8266", "espressif32", "samd"]
+  "platforms": ["atmelavr", "atmelsam", "ststm32", "espressif8266", "espressif32", "samd", "rp2040"]
 }

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino RFID Library for MFRC522 (SPI)
 paragraph=Read/Write a RFID Card or Tag using the ISO/IEC 14443A/MIFARE interface.
 category=Communication
 url=https://github.com/miguelbalboa/rfid
-architectures=avr,megaavr,STM32F1,teensy,esp8266,esp32,samd,atmelsam
+architectures=avr,megaavr,STM32F1,teensy,esp8266,esp32,samd,atmelsam,rp2040


### PR DESCRIPTION
Removes compiler warning when using this library on RP2040 platforms. I know this project is on feature-freeze, but this doesn't change anything for any projects, existing or new, other than removing a compiler warning, however, I do understand if you feel this should not be merged.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
