### PR TITLE
Fix key guessing in RFID-Cloner when key is not first in list

### DIFF
--- a/examples/RFID-Cloner/RFID-Cloner.ino
+++ b/examples/RFID-Cloner/RFID-Cloner.ino
@@ -310,5 +310,14 @@ void keuze1(){ //Read card
             // no need to try other keys for this PICC
             break;
         }
+        
+        // http://arduino.stackexchange.com/a/14316
+        // After a failed authentication, the MIFARE card stops responding
+        // to further communication attempts. We must re-establish the 
+        // connection before trying the next key.
+        if ( ! mfrc522.PICC_IsNewCardPresent())
+            break;
+        if ( ! mfrc522.PICC_ReadCardSerial())
+            break;
     }
 }


### PR DESCRIPTION
## Summary
Fix key guessing failure in the RFID-Cloner example when the correct key is not first in the `knownKeys` array.

## Problem
As reported in #642, key guessing in the RFID-Cloner example fails if the correct key is not the first in the list. All attempts fail with timeout errors, even when the known key is tried.

### Root Cause
After a failed authentication attempt with an incorrect key, MIFARE cards stop responding to further communication. This is a security feature of MIFARE cards that prevents brute-force attacks by requiring a re-selection of the card after failed authentication.

## Solution
Added the same card re-initialization code that already exists in the `rfid_default_keys` example to the `keuze1()` function in RFID-Cloner. After each failed key attempt, we call:

```cpp
// After a failed authentication, the MIFARE card stops responding
// to further communication attempts. We must re-establish the 
// connection before trying the next key.
if ( ! mfrc522.PICC_IsNewCardPresent())
    break;
if ( ! mfrc522.PICC_ReadCardSerial())
    break;
```

This re-establishes communication with the card before trying the next key, allowing the key guessing loop to continue through all keys until the correct one is found.

## Reference
- http://arduino.stackexchange.com/a/14316

## Testing
- Verified that key guessing now works correctly when the known key (e.g., `0xFF...`) is placed at different positions in the `knownKeys` array

Fixes #642